### PR TITLE
Correct sshd path in jailbreak detection code

### DIFF
--- a/Trust/Core/Helpers/DeviceChecker.swift
+++ b/Trust/Core/Helpers/DeviceChecker.swift
@@ -12,7 +12,7 @@ class DeviceChecker: JailbreakChecker {
             "/Applications/Cydia.app",
             "/Library/MobileSubstrate/MobileSubstrate.dylib",
             "/bin/bash",
-            "/usr/sbin  /sshd",
+            "/usr/sbin/sshd",
             "/etc/apt",
             "/private/var/lib/apt/",
         ]


### PR DESCRIPTION
Hi!

This patch fixes `sshd` path at [DeviceChecker.swift:L15](https://github.com/superduper/trust-wallet-ios/blob/master/Trust/Core/Helpers/DeviceChecker.swift#L15).

Best,
Viktor