### PR TITLE
We should clean coordinator stack in restart function.

### DIFF
--- a/Trust/InCoordinator.swift
+++ b/Trust/InCoordinator.swift
@@ -136,7 +136,7 @@ class InCoordinator: Coordinator {
     func restart(for account: Account, in coordinator: TransactionCoordinator) {
         coordinator.navigationController.dismiss(animated: true, completion: nil)
         coordinator.stop()
-        removeCoordinator(coordinator)
+        removeAllCoordinators()
         showTabBar(for: account)
     }
 


### PR DESCRIPTION
We should always clear navigation stack on the restart to avoid zombie objects.

Also could you pls validate if all steps with navigation are working fine. From my side I check this but double check I think is required.

Fix #153