### PR TITLE
Add logic to handle isEmpty Case

### DIFF
--- a/Trust/Tokens/ViewModels/TokenViewCellViewModel.swift
+++ b/Trust/Tokens/ViewModels/TokenViewCellViewModel.swift
@@ -45,8 +45,7 @@ struct TokenViewCellViewModel {
     }
 
     var percentChange: String? {
-        guard let ticker = ticker else { return nil }
-        guard ticker.percent_change_24h.isEmpty else { return "(" + ticker.percent_change_24h + "%)" }
+        guard (ticker?.percent_change_24h.isEmpty)! else { return "(" + (ticker?.percent_change_24h)! + "%)" }
         return nil
     }
 

--- a/Trust/Tokens/ViewModels/TokenViewCellViewModel.swift
+++ b/Trust/Tokens/ViewModels/TokenViewCellViewModel.swift
@@ -46,11 +46,8 @@ struct TokenViewCellViewModel {
 
     var percentChange: String? {
         guard let ticker = ticker else { return nil }
-        let percentChange = ticker.percent_change_24h
-        if percentChange.isEmpty {
-            return nil
-        }
-        return "(" + percentChange + "%)"
+        guard ticker.percent_change_24h.isEmpty else { return "(" + ticker.percent_change_24h + "%)" }
+        return nil
     }
 
     var percentChangeColor: UIColor {

--- a/Trust/Tokens/ViewModels/TokenViewCellViewModel.swift
+++ b/Trust/Tokens/ViewModels/TokenViewCellViewModel.swift
@@ -46,7 +46,11 @@ struct TokenViewCellViewModel {
 
     var percentChange: String? {
         guard let ticker = ticker else { return nil }
-        return "(" + ticker.percent_change_24h + "%)"
+        let percentChange = ticker.percent_change_24h
+        if percentChange.isEmpty {
+            return nil
+        }
+        return "(" + percentChange + "%)"
     }
 
     var percentChangeColor: UIColor {


### PR DESCRIPTION
I felt showing a percentage Symbol when no data was available for a token might cause a bit of confusion for users. 