### PR TITLE
Let Dapps Detect TrustWallet

### DIFF
--- a/Trust/Browser/Factory/WKWebViewConfiguration.swift
+++ b/Trust/Browser/Factory/WKWebViewConfiguration.swift
@@ -77,7 +77,7 @@ extension WKWebViewConfiguration {
         var web3 = new Web3();
         let trustProvider = new web3.providers.HttpProvider("\(session.config.rpcURL.absoluteString)")
         let provider = new web3.providers.HttpProvider("\(session.config.rpcURL.absoluteString)")
-        provider.isTrustWallet = true
+        provider.isTrust = true
         web3.setProvider(trustProvider);
         window.web3 = web3
 

--- a/Trust/Browser/Factory/WKWebViewConfiguration.swift
+++ b/Trust/Browser/Factory/WKWebViewConfiguration.swift
@@ -77,6 +77,7 @@ extension WKWebViewConfiguration {
         var web3 = new Web3();
         let trustProvider = new web3.providers.HttpProvider("\(session.config.rpcURL.absoluteString)")
         let provider = new web3.providers.HttpProvider("\(session.config.rpcURL.absoluteString)")
+        provider.isTrustWallet = true
         web3.setProvider(trustProvider);
         window.web3 = web3
 


### PR DESCRIPTION
Just dipping my toes in to this project...a small gripe I have with Cipher Browser right now. Particularly since MetaMask uses a different web3 version than mist which probably uses a different version than Cipher Browser.

- MetaMask adds `web3.currentProvider.isMetaMask`
- Mist adds `global.mist`

It would be nice to let dapps easily detect the browsers
in which they're running.