### PR TITLE
Remove splash screen on applicationWillEnterForeground

### DIFF
--- a/Trust/AppDelegate.swift
+++ b/Trust/AppDelegate.swift
@@ -44,6 +44,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     func applicationDidEnterBackground(_ application: UIApplication) {
         protectionCoordinator.applicationDidEnterBackground()
     }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        protectionCoordinator.applicationWillEnterForeground()
+    }
+
     func application(_ application: UIApplication, shouldAllowExtensionPointIdentifier extensionPointIdentifier: UIApplicationExtensionPointIdentifier) -> Bool {
         if extensionPointIdentifier == UIApplicationExtensionPointIdentifier.keyboard {
             return false

--- a/Trust/Protection/Coordinators/ProtectionCoordinator.swift
+++ b/Trust/Protection/Coordinators/ProtectionCoordinator.swift
@@ -39,4 +39,8 @@ class ProtectionCoordinator: Coordinator {
     func applicationDidEnterBackground() {
         splashCoordinator.start()
     }
+
+    func applicationWillEnterForeground() {
+        splashCoordinator.stop()
+    }
 }


### PR DESCRIPTION
```
applicationWillEnterForeground

This method is called as an app is preparing to move from the background to the foreground. The app, however, is not moved into an active state without the applicationDidBecomeActive method being called. This method gives a developer the opportunity to re-establish the settings of the previous running state before the app becomes active.
```