### PR TITLE
show symbol for testnets

### DIFF
--- a/Trust/Settings/Types/RPCServers.swift
+++ b/Trust/Settings/Types/RPCServers.swift
@@ -44,10 +44,7 @@ enum RPCServer {
     }
 
     var displayName: String {
-        if self.isTestNetwork {
-            return "\(self.name) (\(self.symbol))"
-        }
-        return self.name
+        return "\(self.name) (\(self.symbol))"
     }
 
     var isTestNetwork: Bool {

--- a/Trust/Settings/Types/RPCServers.swift
+++ b/Trust/Settings/Types/RPCServers.swift
@@ -43,6 +43,13 @@ enum RPCServer {
         }
     }
 
+    var displayName: String {
+        if self.isTestNetwork {
+            return "\(self.name) (\(self.symbol))"
+        }
+        return self.name
+    }
+
     var isTestNetwork: Bool {
         switch self {
         case .main, .poa, .classic, .callisto, .custom: return false

--- a/Trust/Settings/ViewControllers/SettingsViewController.swift
+++ b/Trust/Settings/ViewControllers/SettingsViewController.swift
@@ -53,7 +53,7 @@ class SettingsViewController: FormViewController {
                 $0.value = RPCServer(chainID: strongSelf.config.chainID)
                 $0.selectorTitle = strongSelf.viewModel.networkTitle
                 $0.displayValueFor = { value in
-                    return value?.name
+                    return value?.displayName
                 }
             }.onChange {[weak self] row in
                 self?.config.chainID = row.value?.chainID ?? RPCServer.main.chainID


### PR DESCRIPTION
Since we don't group testnets by network, it's clear to show symbol after testnet name.
e.g: Kovan -> Kovan (ETH)