### PR TITLE
create signMessageData

### DIFF
--- a/Trust/EtherClient/EtherKeystore.swift
+++ b/Trust/EtherClient/EtherKeystore.swift
@@ -309,6 +309,21 @@ open class EtherKeystore: Keystore {
             return .failure(KeystoreError.failedToSignMessage)
         }
     }
+    
+    public func signMessageData(_ message: Data?, for account: Account) -> Result<Data, KeystoreError> {
+        guard
+                let hash = message?.sha3(.keccak256),
+                let password = getPassword(for: account) else {
+            return .failure(KeystoreError.failedToSignMessage)
+        }
+        do {
+            var data = try keyStore.signHash(hash, account: account, password: password)
+            data[64] += 27
+            return .success(data)
+        } catch {
+            return .failure(KeystoreError.failedToSignMessage)
+        }
+    }
 
     func signTransaction(_ transaction: SignTransaction) -> Result<Data, KeystoreError> {
         guard let account = keyStore.account(for: transaction.account.address) else {


### PR DESCRIPTION
SignMessage will work for a pure string like "Hello" but fails when you create a message buffer of [UInt8] and cast it into a string using a utf8 format.

By taking the Data type directly you avoid this pitfall and make it easier on the developer as casting a buffer of [UInt8] works smoothly.

