### PR TITLE
Bug/411

### DIFF
--- a/Trust/EtherClient/ChainState.swift
+++ b/Trust/EtherClient/ChainState.swift
@@ -33,18 +33,30 @@ class ChainState {
     ) {
         self.config = config
         self.defaults = config.defaults
-        self.updateLatestBlock = Timer.scheduledTimer(timeInterval: 6, target: self, selector: #selector(fetch), userInfo: nil, repeats: true)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChainState.stopTimers), name: .UIApplicationWillResignActive, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ChainState.restartTimers), name: .UIApplicationDidBecomeActive, object: nil)
+        runScheduledTimers()
     }
-
     func start() {
         fetch()
     }
-
     func stop() {
         updateLatestBlock?.invalidate()
         updateLatestBlock = nil
     }
-
+    @objc func stopTimers() {
+        updateLatestBlock?.invalidate()
+        updateLatestBlock = nil
+    }
+    @objc func restartTimers() {
+        runScheduledTimers()
+    }
+    private func runScheduledTimers() {
+        guard updateLatestBlock == nil else {
+            return
+        }
+        self.updateLatestBlock = Timer.scheduledTimer(timeInterval: 6, target: self, selector: #selector(fetch), userInfo: nil, repeats: true)
+    }
     @objc func fetch() {
         let request = EtherServiceRequest(batch: BatchFactory().create(BlockNumberRequest()))
         Session.send(request) { [weak self] result in
@@ -56,12 +68,15 @@ class ChainState {
             }
         }
     }
-
     func confirmations(fromBlock: Int) -> Int? {
         guard fromBlock > 0 else { return nil }
         let block = latestBlock - fromBlock
         guard latestBlock != 0, block > 0 else { return nil }
         return max(0, block)
     }
-
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        updateLatestBlock?.invalidate()
+        updateLatestBlock = nil
+    }
 }

--- a/Trust/EtherClient/ChainState.swift
+++ b/Trust/EtherClient/ChainState.swift
@@ -40,6 +40,7 @@ class ChainState {
     func start() {
         fetch()
     }
+
     func stop() {
         updateLatestBlock?.invalidate()
         updateLatestBlock = nil
@@ -68,6 +69,7 @@ class ChainState {
             }
         }
     }
+
     func confirmations(fromBlock: Int) -> Int? {
         guard fromBlock > 0 else { return nil }
         let block = latestBlock - fromBlock

--- a/Trust/Tokens/Types/TokensDataStore.swift
+++ b/Trust/Tokens/Types/TokensDataStore.swift
@@ -29,7 +29,6 @@ class TokensDataStore {
     weak var delegate: TokensDataStoreDelegate?
     let realm: Realm
     var tickers: [String: CoinTicker]? = .none
-    var pricesTimer: Timer?
     var ethTimer: Timer?
     //We should refresh prices every 5 minutes.
     let intervalToRefreshPrices = 300.0
@@ -59,8 +58,7 @@ class TokensDataStore {
         self.web3 = web3
         self.realm = realm
         self.addEthToken()
-        self.scheduledTimerForPricesUpdate()
-        self.scheduledTimerForEthBalanceUpdate()
+        scheduledTimerForEthBalanceUpdate()
         NotificationCenter.default.addObserver(self, selector: #selector(TokensDataStore.stopTimers), name: .UIApplicationWillResignActive, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TokensDataStore.restartTimers), name: .UIApplicationDidBecomeActive, object: nil)
     }
@@ -221,16 +219,8 @@ class TokensDataStore {
             }
         }
     }
-    private func scheduledTimerForPricesUpdate() {
-        guard pricesTimer == nil else {
-            return
-        }
-        pricesTimer = Timer.scheduledTimer(timeInterval: intervalToRefreshPrices, target: BlockOperation { [weak self] in
-            self?.updatePrices()
-        }, selector: #selector(Operation.main), userInfo: nil, repeats: true)
-    }
     private func scheduledTimerForEthBalanceUpdate() {
-        guard pricesTimer == nil else {
+        guard ethTimer == nil else {
             return
         }
         ethTimer = Timer.scheduledTimer(timeInterval: intervalToETHRefresh, target: BlockOperation { [weak self] in
@@ -238,20 +228,15 @@ class TokensDataStore {
         }, selector: #selector(Operation.main), userInfo: nil, repeats: true)
     }
     @objc func stopTimers() {
-        pricesTimer?.invalidate()
-        pricesTimer = nil
         ethTimer?.invalidate()
-        pricesTimer = nil
+        ethTimer = nil
     }
     @objc func restartTimers() {
-        scheduledTimerForPricesUpdate()
         scheduledTimerForEthBalanceUpdate()
     }
     deinit {
         NotificationCenter.default.removeObserver(self)
-        pricesTimer?.invalidate()
-        pricesTimer = nil
         ethTimer?.invalidate()
-        pricesTimer = nil
+        ethTimer = nil
     }
 }

--- a/Trust/Tokens/Types/TokensDataStore.swift
+++ b/Trust/Tokens/Types/TokensDataStore.swift
@@ -71,16 +71,19 @@ class TokensDataStore {
             add(tokens: [etherToken])
         }
     }
+
     var objects: [TokenObject] {
         return realm.objects(TokenObject.self)
             .sorted(byKeyPath: "contract", ascending: true)
             .filter { !$0.contract.isEmpty }
     }
+
     var enabledObject: [TokenObject] {
         return realm.objects(TokenObject.self)
             .sorted(byKeyPath: "contract", ascending: true)
             .filter { !$0.isDisabled }
     }
+
     static func update(in realm: Realm, tokens: [Token]) {
         realm.beginWrite()
         for token in tokens {
@@ -94,10 +97,12 @@ class TokensDataStore {
         }
         try! realm.commitWrite()
     }
+
     func fetch() {
         updatePrices()
         refreshBalance()
     }
+
     func refreshBalance() {
         guard !enabledObject.isEmpty else {
             updateDelegate()
@@ -139,12 +144,15 @@ class TokensDataStore {
         let tokensViewModel = TokensViewModel( tokens: enabledObject, tickers: tickers )
         delegate?.didUpdate(result: .success( tokensViewModel ))
     }
+
     func coinTicker(for token: TokenObject) -> CoinTicker? {
         return tickers?[token.contract]
     }
+
     func handleError(error: Error) {
         delegate?.didUpdate(result: .failure(TokenError.failedToFetch))
     }
+
     func addCustom(token: ERC20Token) {
         let newToken = TokenObject(
             contract: token.contract.description,
@@ -156,6 +164,7 @@ class TokensDataStore {
         )
         add(tokens: [newToken])
     }
+
     func updatePrices() {
         let tokens = objects.map { TokenPrice(contract: $0.contract, symbol: $0.symbol) }
         let tokensPrice = TokensPrice(
@@ -176,6 +185,7 @@ class TokensDataStore {
             } catch { }
         }
     }
+
     @discardableResult
     func add(tokens: [TokenObject]) -> [TokenObject] {
         realm.beginWrite()
@@ -183,20 +193,24 @@ class TokensDataStore {
         try! realm.commitWrite()
         return tokens
     }
+
     func delete(tokens: [TokenObject]) {
         realm.beginWrite()
         realm.delete(tokens)
         try! realm.commitWrite()
     }
+
     func deleteAll() {
         try! realm.write {
             realm.delete(realm.objects(TokenObject.self))
         }
     }
+
     enum TokenUpdate {
         case value(BigInt)
         case isDisabled(Bool)
     }
+
     func update(token: TokenObject, action: TokenUpdate) {
         try! realm.write {
             switch action {

--- a/Trust/Transactions/Coordinators/TransactionDataCoordinator.swift
+++ b/Trust/Transactions/Coordinators/TransactionDataCoordinator.swift
@@ -81,6 +81,7 @@ class TransactionDataCoordinator {
         fetchTransactions()
         fetchPendingTransactions()
     }
+
     @objc func fetchTransactions() {
         let startBlock: Int = {
             guard let transaction = storage.completedObjects.first else { return 1 }

--- a/Trust/Transactions/Coordinators/TransactionDataCoordinator.swift
+++ b/Trust/Transactions/Coordinators/TransactionDataCoordinator.swift
@@ -45,28 +45,42 @@ class TransactionDataCoordinator {
     ) {
         self.session = session
         self.storage = storage
+        NotificationCenter.default.addObserver(self, selector: #selector(TransactionDataCoordinator.stopTimers), name: .UIApplicationWillResignActive, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(TransactionDataCoordinator.restartTimers), name: .UIApplicationDidBecomeActive, object: nil)
     }
 
     func start() {
+        runScheduledTimers()
+        // Start fetching all transactions process.
+        if transactionsTracker.fetchingState != .done {
+            initialFetch(for: session.account.address, page: 0) { _ in }
+        }
+    }
+    @objc func stopTimers() {
+        timer?.invalidate()
+        timer = nil
+        updateTransactionsTimer?.invalidate()
+        updateTransactionsTimer = nil
+    }
+    @objc func restartTimers() {
+        runScheduledTimers()
+    }
+    private func runScheduledTimers() {
+        guard timer == nil, updateTransactionsTimer == nil else {
+            return
+        }
         timer = Timer.scheduledTimer(timeInterval: 5, target: BlockOperation { [weak self] in
             self?.fetchPending()
         }, selector: #selector(Operation.main), userInfo: nil, repeats: true)
         updateTransactionsTimer = Timer.scheduledTimer(timeInterval: 15, target: BlockOperation { [weak self] in
             self?.fetchTransactions()
         }, selector: #selector(Operation.main), userInfo: nil, repeats: true)
-
-        // Start fetching all transactions process.
-        if transactionsTracker.fetchingState != .done {
-            initialFetch(for: session.account.address, page: 0) { _ in }
-        }
     }
-
     func fetch() {
         session.refresh(.balance)
         fetchTransactions()
         fetchPendingTransactions()
     }
-
     @objc func fetchTransactions() {
         let startBlock: Int = {
             guard let transaction = storage.completedObjects.first else { return 1 }
@@ -214,11 +228,10 @@ class TransactionDataCoordinator {
             }
         }
     }
-
     func stop() {
+        NotificationCenter.default.removeObserver(self)
         timer?.invalidate()
         timer = nil
-
         updateTransactionsTimer?.invalidate()
         updateTransactionsTimer = nil
     }


### PR DESCRIPTION
In this issue I invalidate all timers in UIApplicationWillResignActive event and restore them in UIApplicationDidBecomeActive.

In such way we remove cases when after restore of the app timers are going crazy.

This is the most simples way to manage timers in our case.