### PR TITLE
Fix danger SwifLint

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -2,4 +2,5 @@
 warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
 
 # swiftlint
+swiftlint.binary_path = './Pods/SwiftLint/swiftlint'
 swiftlint.lint_files


### PR DESCRIPTION
We now use the version of SwiftLint that runs locally through Xcode. This pulled from the PODS directory.  This should fix the warning: Delegate protocols should be class-only so they can be weakly referenced.