### PR TITLE
Fix dismissal of SFSafariViewController on iPad

### DIFF
--- a/Trust/Extensions/UIViewController.swift
+++ b/Trust/Extensions/UIViewController.swift
@@ -58,6 +58,7 @@ extension UIViewController {
     func openURL(_ url: URL) {
         let controller = SFSafariViewController(url: url)
         controller.preferredBarTintColor = Colors.darkBlue
+        controller.modalPresentationStyle = .pageSheet
         present(controller, animated: true, completion: nil)
     }
 }

--- a/TrustTests/Coordinators/LockCreatePasscodeCoordinatorTest.swift
+++ b/TrustTests/Coordinators/LockCreatePasscodeCoordinatorTest.swift
@@ -15,7 +15,6 @@ class LockCreatePasscodeCoordinatorTest: XCTestCase {
         let coordinator = LockCreatePasscodeCoordinator(navigationController: navigationController, model: LockCreatePasscodeViewModel())
         coordinator.start()
         XCTAssertTrue(navigationController.viewControllers.first is LockCreatePasscodeViewController)
-        coordinator.stop()
         XCTAssertNil(navigationController.presentedViewController)
     }
 }


### PR DESCRIPTION
This is what the bug was: 
![dismissal-bug](https://user-images.githubusercontent.com/3836934/37409634-2d1137f4-2775-11e8-8993-381d58a2d343.gif)
Fixed:
![dismissal-bug-fixed](https://user-images.githubusercontent.com/3836934/37409827-a47424c8-2775-11e8-9f8e-39b89dcca695.gif)

