### PR TITLE
Update Eureka

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ target 'Trust' do
   pod 'R.swift'
   pod 'JSONRPCKit', :git=> 'https://github.com/bricklife/JSONRPCKit.git'
   pod 'APIKit'
-  pod 'Eureka', '~> 4.0.1'
+  pod 'Eureka', '~> 4.1.1'
   pod 'MBProgressHUD'
   pod 'StatefulViewController'
   pod 'QRCodeReaderViewController', :git=>'https://github.com/yannickl/QRCodeReaderViewController.git', :branch=>'master'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - Crashlytics (3.9.3):
     - Fabric (~> 1.7.2)
   - CryptoSwift (0.8.0)
-  - Eureka (4.0.1)
+  - Eureka (4.1.1)
   - Fabric (1.7.2)
   - JavaScriptKit (1.0.0):
     - Result (~> 3.1)
@@ -57,7 +57,7 @@ DEPENDENCIES:
   - Branch
   - Crashlytics
   - CryptoSwift (from `https://github.com/krzyzanowskim/CryptoSwift`, branch `master`)
-  - Eureka (~> 4.0.1)
+  - Eureka (~> 4.1.1)
   - Fabric
   - JavaScriptKit
   - JdenticonSwift
@@ -112,7 +112,7 @@ SPEC CHECKSUMS:
   Branch: 4f0482418d99e77d15b0e6065ef216c10e24797b
   Crashlytics: dbb07d01876c171c5ccbdf7826410380189e452c
   CryptoSwift: 475ae2a25439f52412686d68b854c0ca724c8dfd
-  Eureka: c8bd5cc07143b6f66268c208d28a246c99b41955
+  Eureka: b88fb930e42c79f8c03c373d0fcdc28c1d6c50ed
   Fabric: 9cd6a848efcf1b8b07497e0b6a2e7d336353ba15
   JavaScriptKit: 9ff565209e6efe21bcb9c6d6ca3e863a67a8ecf7
   JdenticonSwift: bc532f2761566eb29f26b085e5f72de25bc065ce
@@ -139,6 +139,6 @@ SPEC CHECKSUMS:
   TrustWeb3Provider: 3d5c9f17aa6cc3fcd083d232aed5e90615be5383
   URLNavigator: af5582fbbb3586c958be16835d799bfdb23a4793
 
-PODFILE CHECKSUM: d70134c067fee2a555025b2d122b92c0027618b6
+PODFILE CHECKSUM: ce1115872c4fffb95ee1a92013e9ae0ba9b20ebc
 
 COCOAPODS: 1.4.0

--- a/Trust.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Trust.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
The  `IDEWorkspaceChecks.plist` is new with Xcode 9.3. Is here a bit of info on it from the release notes. 

>  Xcode 9.3 adds a new IDEWorkspaceChecks.plist file to a workspace’s shared data, to store the state of necessary workspace checks. Committing this file to source control will prevent unnecessary rerunning of those checks for each user opening the workspace.