### PR TITLE
Fix open trust:// crash

### DIFF
--- a/Trust/AppDelegate.swift
+++ b/Trust/AppDelegate.swift
@@ -64,7 +64,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 //    }
 
     // Respond to URI scheme links
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
         return urlNavigatorCoordinator.application(app, open: url, options: options)
     }
 

--- a/Trust/AppDelegate.swift
+++ b/Trust/AppDelegate.swift
@@ -64,8 +64,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 //    }
 
     // Respond to URI scheme links
-    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        return urlNavigatorCoordinator.application(application, open: url, sourceApplication: sourceApplication, annotation: annotation)
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        return urlNavigatorCoordinator.application(app, open: url, options: options)
     }
 
     // Respond to Universal Links

--- a/Trust/Core/Coordinators/BranchCoordinator.swift
+++ b/Trust/Core/Coordinators/BranchCoordinator.swift
@@ -29,7 +29,7 @@ class BranchCoordinator {
         return Branch.getInstance().application(application, open: url, sourceApplication: sourceApplication, annotation: annotation)
     }
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
         return Branch.getInstance().application(app, open: url, options: options)
     }
 }

--- a/Trust/Core/Coordinators/BranchCoordinator.swift
+++ b/Trust/Core/Coordinators/BranchCoordinator.swift
@@ -28,4 +28,8 @@ class BranchCoordinator {
     func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
         return Branch.getInstance().application(application, open: url, sourceApplication: sourceApplication, annotation: annotation)
     }
+
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        return Branch.getInstance().application(app, open: url, options: options)
+    }
 }

--- a/Trust/Core/Coordinators/URLNavigatorCoordinator.swift
+++ b/Trust/Core/Coordinators/URLNavigatorCoordinator.swift
@@ -7,8 +7,8 @@ struct URLNavigatorCoordinator {
     let branch = BranchCoordinator()
     let navigator = Navigator()
 
-    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        var handled = branch.application(application, open: url, sourceApplication: sourceApplication, annotation: annotation)
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
+        var handled = branch.application(app, open: url, options: options)
         if !handled {
             handled = navigator.open(url)
         }


### PR DESCRIPTION
Replace `func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool` (deprecated)
with `func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool`