### PR TITLE
Add transactionsObservation on viewDidLoad

### DIFF
--- a/Trust/Transactions/ViewControllers/TransactionsViewController.swift
+++ b/Trust/Transactions/ViewControllers/TransactionsViewController.swift
@@ -80,17 +80,13 @@ class TransactionsViewController: UIViewController {
         runScheduledTimers()
         NotificationCenter.default.addObserver(self, selector: #selector(TransactionsViewController.stopTimers), name: .UIApplicationWillResignActive, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TransactionsViewController.restartTimers), name: .UIApplicationDidBecomeActive, object: nil)
-    }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        viewModel.invalidateTransactionsObservation()
+        transactionsObservation()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         refreshControl.endRefreshing()
-        transactionsObservation()
         fetch()
     }
 


### PR DESCRIPTION
Once we create new transaction and place in the store we show badge for Transaction tab, but if we don't have this observation then nothing will be shown.

Can you double check that this won't cause any memory leaks?