### PR TITLE
Set proper method to show keyboard.

### DIFF
--- a/Trust/Lock/ViewControllers/LockPasscodeViewController.swift
+++ b/Trust/Lock/ViewControllers/LockPasscodeViewController.swift
@@ -20,8 +20,8 @@ class LockPasscodeViewController: UIViewController {
         self.configureInvisiblePasscodeField()
         self.configureLockView()
     }
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         if !invisiblePasscodeField.isFirstResponder && !lock.incorrectMaxAttemptTimeIsSet() {
             invisiblePasscodeField.becomeFirstResponder()
         }


### PR DESCRIPTION
Some times becomeFirstResponder() could have issue during loading of the view. So for now we will show keyboard only when we finally present view.

Fix #464 