### PR TITLE
Fix issue with CoinTicker price

### DIFF
--- a/Trust.xcodeproj/project.pbxproj
+++ b/Trust.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		29FF6D6B2011D2AF00A3011C /* InCoordinatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FF6D6A2011D2AF00A3011C /* InCoordinatorError.swift */; };
 		29FF6D73201200D500A3011C /* FieldAppereance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FF6D72201200D500A3011C /* FieldAppereance.swift */; };
 		3CDDD1E2CD1B0180754B7992 /* Pods_Trust.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 646C8C822C986358D7388602 /* Pods_Trust.framework */; };
+		4E9A9D0820B2C52500180054 /* CoinTicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9A9D0720B2C52500180054 /* CoinTicker.swift */; };
 		4EEE540D207996EF007D300D /* TokensDataStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEE540C207996EF007D300D /* TokensDataStoreTest.swift */; };
 		4EEE540F20799701007D300D /* CoinTicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEE540E20799700007D300D /* CoinTicker.swift */; };
 		613D04891FDE15F8008DE72E /* COMODO ECC Domain Validation Secure Server CA 2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 613D04881FDE15F8008DE72E /* COMODO ECC Domain Validation Secure Server CA 2.cer */; };
@@ -736,6 +737,7 @@
 		477899BEAA4489DA423E8857 /* Pods-TrustUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TrustUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TrustUITests/Pods-TrustUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		486727FADFF5D4F43B985920 /* Pods_OpenInTrust.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenInTrust.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DB8204016307EAFC079EA48 /* Pods-Trust.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Trust.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Trust/Pods-Trust.debug.xcconfig"; sourceTree = "<group>"; };
+		4E9A9D0720B2C52500180054 /* CoinTicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinTicker.swift; sourceTree = "<group>"; };
 		4EEE540C207996EF007D300D /* TokensDataStoreTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensDataStoreTest.swift; sourceTree = "<group>"; };
 		4EEE540E20799700007D300D /* CoinTicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoinTicker.swift; sourceTree = "<group>"; };
 		613D04881FDE15F8008DE72E /* COMODO ECC Domain Validation Secure Server CA 2.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = "COMODO ECC Domain Validation Secure Server CA 2.cer"; sourceTree = "<group>"; };
@@ -2032,6 +2034,7 @@
 				298994FF2053D52700576B8B /* FakeRealm.swift */,
 				776C114D2060E61500449539 /* TokenObject.swift */,
 				773B8DBD2071859A00D05690 /* GetNonceProvider.swift */,
+				4E9A9D0720B2C52500180054 /* CoinTicker.swift */,
 			);
 			path = Factories;
 			sourceTree = "<group>";
@@ -3264,6 +3267,7 @@
 				29FF130D1F7626E800AFD326 /* FakeNavigationController.swift in Sources */,
 				299573A41FA27A15006F17FD /* TestKeyStore.swift in Sources */,
 				CCA4FE3A1FD42B4100749AE4 /* FakeJailbreakChecker.swift in Sources */,
+				4E9A9D0820B2C52500180054 /* CoinTicker.swift in Sources */,
 				29F114F81FA8165200114A29 /* SendCoordinatorTests.swift in Sources */,
 				4EEE540D207996EF007D300D /* TokensDataStoreTest.swift in Sources */,
 				299573A21FA1F369006F17FD /* QRURLParserTests.swift in Sources */,

--- a/Trust/Core/Network/TrustNetwork.swift
+++ b/Trust/Core/Network/TrustNetwork.swift
@@ -54,7 +54,7 @@ class TrustNetwork: NetworkProtocol {
             do {
                 let rawTickers = try response.map([CoinTicker].self, atKeyPath: "response", using: JSONDecoder())
                 let tickers = rawTickers.map {rawTicker in
-                    return self.getTickerFrom(rawTicker: rawTicker, withKey: self.config.tickersKey)
+                    return self.getTickerFrom(rawTicker: rawTicker, withKey: CoinTickerKeyFactory.makeCurrencyKey(for: self.config))
                 }
                 completion(tickers)
             } catch {
@@ -141,7 +141,7 @@ class TrustNetwork: NetworkProtocol {
                 do {
                     let rawTickers = try response.map([CoinTicker].self, atKeyPath: "response", using: JSONDecoder())
                     let tickers = rawTickers.map {rawTicker in
-                        return self.getTickerFrom(rawTicker: rawTicker, withKey: self.config.tickersKey)
+                        return self.getTickerFrom(rawTicker: rawTicker, withKey: CoinTickerKeyFactory.makeCurrencyKey(for: self.config))
                     }
                     seal.fulfill(tickers)
                 } catch {

--- a/Trust/Core/Network/TrustNetwork.swift
+++ b/Trust/Core/Network/TrustNetwork.swift
@@ -54,7 +54,7 @@ class TrustNetwork: NetworkProtocol {
             do {
                 let rawTickers = try response.map([CoinTicker].self, atKeyPath: "response", using: JSONDecoder())
                 let tickers = rawTickers.map {rawTicker in
-                    return self.getTickerFrom(rawTicker: rawTicker, withKey: CoinTickerKeyFactory.makeCurrencyKey(for: self.config))
+                    return self.getTickerFrom(rawTicker: rawTicker, withKey: CoinTickerKeyMaker.makeCurrencyKey(for: self.config))
                 }
                 completion(tickers)
             } catch {
@@ -141,7 +141,7 @@ class TrustNetwork: NetworkProtocol {
                 do {
                     let rawTickers = try response.map([CoinTicker].self, atKeyPath: "response", using: JSONDecoder())
                     let tickers = rawTickers.map {rawTicker in
-                        return self.getTickerFrom(rawTicker: rawTicker, withKey: CoinTickerKeyFactory.makeCurrencyKey(for: self.config))
+                        return self.getTickerFrom(rawTicker: rawTicker, withKey: CoinTickerKeyMaker.makeCurrencyKey(for: self.config))
                     }
                     seal.fulfill(tickers)
                 } catch {

--- a/Trust/Settings/Types/Config.swift
+++ b/Trust/Settings/Types/Config.swift
@@ -64,8 +64,4 @@ struct Config {
         get { return defaults.bool(forKey: Keys.testNetworkWarningOff) }
         set { defaults.set(newValue, forKey: Keys.testNetworkWarningOff) }
     }
-
-    var tickersKey: String {
-        return "tickers-" + self.currency.rawValue + "-" + String(self.chainID)
-    }
 }

--- a/Trust/Settings/Types/Config.swift
+++ b/Trust/Settings/Types/Config.swift
@@ -66,8 +66,6 @@ struct Config {
     }
 
     var tickersKey: String {
-        get {
-            return "tickers-" + self.currency.rawValue + "-" + String(self.chainID)
-        }
+        return "tickers-" + self.currency.rawValue + "-" + String(self.chainID)
     }
 }

--- a/Trust/Tokens/Storage/TokensDataStore.swift
+++ b/Trust/Tokens/Storage/TokensDataStore.swift
@@ -55,7 +55,7 @@ class TokensDataStore {
 
     func coinTicker(for token: TokenObject) -> CoinTicker? {
         return tickers().first(where: {
-            return $0.key == CoinTickerKeyFactory.makePrimaryKey(symbol: $0.symbol, contract: token.contract, currencyKey: $0.tickersKey)
+            return $0.key == CoinTickerKeyMaker.makePrimaryKey(symbol: $0.symbol, contract: token.contract, currencyKey: $0.tickersKey)
         })
     }
 
@@ -172,7 +172,7 @@ class TokensDataStore {
     }
 
     private var tickerResultsByTickersKey: Results<CoinTicker> {
-        return realm.objects(CoinTicker.self).filter("tickersKey == %@", CoinTickerKeyFactory.makeCurrencyKey(for: config))
+        return realm.objects(CoinTicker.self).filter("tickersKey == %@", CoinTickerKeyMaker.makeCurrencyKey(for: config))
     }
 
     func deleteAllExistingTickers() {

--- a/Trust/Tokens/Storage/TokensDataStore.swift
+++ b/Trust/Tokens/Storage/TokensDataStore.swift
@@ -54,7 +54,9 @@ class TokensDataStore {
     }
 
     func coinTicker(for token: TokenObject) -> CoinTicker? {
-        return tickers().first(where: { $0.contract == token.contract })
+        return tickers().first(where: {
+            return $0.key == CoinTicker.getKey(symbol: $0.symbol, contract: token.contract, tickersKey: $0.tickersKey)
+        })
     }
 
     func addCustom(token: ERC20Token) {

--- a/Trust/Tokens/Storage/TokensDataStore.swift
+++ b/Trust/Tokens/Storage/TokensDataStore.swift
@@ -55,7 +55,7 @@ class TokensDataStore {
 
     func coinTicker(for token: TokenObject) -> CoinTicker? {
         return tickers().first(where: {
-            return $0.key == CoinTicker.getKey(symbol: $0.symbol, contract: token.contract, tickersKey: $0.tickersKey)
+            return $0.key == CoinTickerKeyFactory.makePrimaryKey(symbol: $0.symbol, contract: token.contract, currencyKey: $0.tickersKey)
         })
     }
 
@@ -172,7 +172,7 @@ class TokensDataStore {
     }
 
     private var tickerResultsByTickersKey: Results<CoinTicker> {
-        return realm.objects(CoinTicker.self).filter("tickersKey == %@", config.tickersKey)
+        return realm.objects(CoinTicker.self).filter("tickersKey == %@", CoinTickerKeyFactory.makeCurrencyKey(for: config))
     }
 
     func deleteAllExistingTickers() {

--- a/Trust/Tokens/Types/CoinTicker.swift
+++ b/Trust/Tokens/Types/CoinTicker.swift
@@ -25,11 +25,7 @@ class CoinTicker: Object, Decodable {
         self.percent_change_24h = percent_change_24h
         self.contract = contract
         self.tickersKey = tickersKey
-        self.key = CoinTicker.getKey(symbol: symbol, contract: contract, tickersKey: tickersKey)
-    }
-
-    static func getKey(symbol: String, contract: String, tickersKey: String) -> String {
-        return "\(symbol)_\(contract)_\(tickersKey)"
+        self.key = CoinTickerKeyFactory.makePrimaryKey(symbol: symbol, contract: contract, currencyKey: tickersKey)
     }
 
     required init() {
@@ -67,5 +63,15 @@ extension CoinTicker {
                 ),
             ]
         )
+    }
+}
+
+struct CoinTickerKeyFactory {
+    static func makePrimaryKey(symbol: String, contract: String, currencyKey: String) -> String {
+        return "\(symbol)_\(contract)_\(currencyKey)"
+    }
+
+    static func makeCurrencyKey(for config: Config) -> String {
+        return "tickers-" + config.currency.rawValue + "-" + String(config.chainID)
     }
 }

--- a/Trust/Tokens/Types/CoinTicker.swift
+++ b/Trust/Tokens/Types/CoinTicker.swift
@@ -25,7 +25,7 @@ class CoinTicker: Object, Decodable {
         self.percent_change_24h = percent_change_24h
         self.contract = contract
         self.tickersKey = tickersKey
-        self.key = CoinTickerKeyFactory.makePrimaryKey(symbol: symbol, contract: contract, currencyKey: tickersKey)
+        self.key = CoinTickerKeyMaker.makePrimaryKey(symbol: symbol, contract: contract, currencyKey: tickersKey)
     }
 
     required init() {
@@ -66,7 +66,7 @@ extension CoinTicker {
     }
 }
 
-struct CoinTickerKeyFactory {
+struct CoinTickerKeyMaker {
     static func makePrimaryKey(symbol: String, contract: String, currencyKey: String) -> String {
         return "\(symbol)_\(contract)_\(currencyKey)"
     }

--- a/Trust/Tokens/Types/CoinTicker.swift
+++ b/Trust/Tokens/Types/CoinTicker.swift
@@ -25,7 +25,11 @@ class CoinTicker: Object, Decodable {
         self.percent_change_24h = percent_change_24h
         self.contract = contract
         self.tickersKey = tickersKey
-        self.key = "\(symbol)_\(contract)_\(tickersKey)"
+        self.key = CoinTicker.getKey(symbol: symbol, contract: contract, tickersKey: tickersKey)
+    }
+
+    static func getKey(symbol: String, contract: String, tickersKey: String) -> String {
+        return "\(symbol)_\(contract)_\(tickersKey)"
     }
 
     required init() {

--- a/Trust/Tokens/ViewModels/TokensViewModel.swift
+++ b/Trust/Tokens/ViewModels/TokensViewModel.swift
@@ -87,9 +87,11 @@ class TokensViewModel: NSObject {
     }
 
     private func amount(for token: TokenObject) -> Double {
-        guard let tickersSymbol = store.tickers().first(where: { $0.contract == token.contract }) else { return 0 }
+        guard let coinTicker = store.coinTicker(for: token) else {
+            return 0
+        }
         let tokenValue = CurrencyFormatter.plainFormatter.string(from: token.valueBigInt, decimals: token.decimals).doubleValue
-        let price = Double(tickersSymbol.price) ?? 0
+        let price = Double(coinTicker.price) ?? 0
         return tokenValue * price
     }
 

--- a/TrustTests/Factories/CoinTicker.swift
+++ b/TrustTests/Factories/CoinTicker.swift
@@ -1,0 +1,27 @@
+// Copyright SIX DAY LLC. All rights reserved.
+
+import Foundation
+@testable import Trust
+
+extension CoinTicker {
+    static func make(
+            symbol: String = "symbol",
+            price: String = "0",
+            percent_change_24h: String = "0",
+            contract: String = "contract",
+            tickersKey: String = "tickersKey",
+            key: String? = nil
+        ) -> CoinTicker {
+        let coinTicker = CoinTicker(
+            symbol: symbol,
+            price: price,
+            percent_change_24h: percent_change_24h,
+            contract: contract,
+            tickersKey: tickersKey
+        )
+        if let keyValue = key {
+            coinTicker.key = keyValue
+        }
+        return coinTicker
+    }
+}

--- a/TrustTests/Factories/CoinTicker.swift
+++ b/TrustTests/Factories/CoinTicker.swift
@@ -9,7 +9,7 @@ extension CoinTicker {
             price: String = "0",
             percent_change_24h: String = "0",
             contract: String = "contract",
-            tickersKey: String = "tickersKey",
+            currencyKey: String = "currencyKey",
             key: String? = nil
         ) -> CoinTicker {
         let coinTicker = CoinTicker(
@@ -17,7 +17,7 @@ extension CoinTicker {
             price: price,
             percent_change_24h: percent_change_24h,
             contract: contract,
-            tickersKey: tickersKey
+            tickersKey: currencyKey
         )
         if let keyValue = key {
             coinTicker.key = keyValue

--- a/TrustTests/Factories/FakeTokensDataStore.swift
+++ b/TrustTests/Factories/FakeTokensDataStore.swift
@@ -23,7 +23,7 @@ class FakeTokensDataStore: TokensDataStore {
 }
 
 class FakeCoinTickerFactory {
-    static let currencyKey = CoinTickerKeyFactory.makeCurrencyKey(for: Config.make())
+    static let currencyKey = CoinTickerKeyMaker.makeCurrencyKey(for: Config.make())
 
     class func make3UniqueCionTickers() -> [CoinTicker] {
         return [

--- a/TrustTests/Factories/FakeTokensDataStore.swift
+++ b/TrustTests/Factories/FakeTokensDataStore.swift
@@ -13,7 +13,7 @@ class FakeTokensDataStore: TokensDataStore {
 
     func makeFakeTicker() -> [CoinTicker]  {
         let price = 947.102
-        let coinTiekcer = CoinTicker(symbol: "ETH", price: "\(price)", percent_change_24h: "-2.39", contract: config.server.address, tickersKey: "tickersKey")
+        let coinTiekcer = CoinTicker.make(symbol: "ETH", price: "\(price)", percent_change_24h: "-2.39", contract: config.server.address)
         return [coinTiekcer]
     }
 
@@ -27,23 +27,16 @@ class FakeCoinTickerFactory {
 
     class func make3UniqueCionTickers() -> [CoinTicker] {
         return [
-            CoinTicker(symbol: "symbol1", price: "10", percent_change_24h: "percent_change_24h_1", contract: "contract1", tickersKey: currencyKey),
-            CoinTicker(symbol: "symbol2", price: "20", percent_change_24h: "percent_change_24h_2", contract: "contract2", tickersKey: currencyKey),
-            CoinTicker(symbol: "symbol3", price: "30", percent_change_24h: "percent_change_24h_3", contract: "contract3", tickersKey: currencyKey),
+            CoinTicker.make(symbol: "symbol1", price: "10", contract: "contract1", tickersKey: currencyKey),
+            CoinTicker.make(symbol: "symbol2", price: "20", contract: "contract2", tickersKey: currencyKey),
+            CoinTicker.make(symbol: "symbol3", price: "30", contract: "contract3", tickersKey: currencyKey),
         ]
     }
 
     class func make2DuplicateCionTickersWithDifferentKey() -> [CoinTicker] {
         return [
-            {
-                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: currencyKey)
-                coinTicker.key = "old-key"
-                return coinTicker
-            }(),
-            {
-                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: currencyKey)
-                return coinTicker
-            }()
+            CoinTicker.make(symbol: "same-symbol", contract: "same-contract-address", tickersKey: currencyKey, key: "old-key"),
+            CoinTicker.make(symbol: "same-symbol", contract: "same-contract-address", tickersKey: currencyKey),
         ]
     }
 }

--- a/TrustTests/Factories/FakeTokensDataStore.swift
+++ b/TrustTests/Factories/FakeTokensDataStore.swift
@@ -21,3 +21,29 @@ class FakeTokensDataStore: TokensDataStore {
         return makeFakeTicker()
     }
 }
+
+class FakeCoinTickerFactory {
+    static let currencyKey = CoinTickerKeyFactory.makeCurrencyKey(for: Config.make())
+
+    class func make3UniqueCionTickers() -> [CoinTicker] {
+        return [
+            CoinTicker(symbol: "symbol1", price: "10", percent_change_24h: "percent_change_24h_1", contract: "contract1", tickersKey: currencyKey),
+            CoinTicker(symbol: "symbol2", price: "20", percent_change_24h: "percent_change_24h_2", contract: "contract2", tickersKey: currencyKey),
+            CoinTicker(symbol: "symbol3", price: "30", percent_change_24h: "percent_change_24h_3", contract: "contract3", tickersKey: currencyKey),
+        ]
+    }
+
+    class func make2DuplicateCionTickersWithDifferentKey() -> [CoinTicker] {
+        return [
+            {
+                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: currencyKey)
+                coinTicker.key = "old-key"
+                return coinTicker
+            }(),
+            {
+                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: currencyKey)
+                return coinTicker
+            }()
+        ]
+    }
+}

--- a/TrustTests/Factories/FakeTokensDataStore.swift
+++ b/TrustTests/Factories/FakeTokensDataStore.swift
@@ -27,16 +27,16 @@ class FakeCoinTickerFactory {
 
     class func make3UniqueCionTickers() -> [CoinTicker] {
         return [
-            CoinTicker.make(symbol: "symbol1", price: "10", contract: "contract1", tickersKey: currencyKey),
-            CoinTicker.make(symbol: "symbol2", price: "20", contract: "contract2", tickersKey: currencyKey),
-            CoinTicker.make(symbol: "symbol3", price: "30", contract: "contract3", tickersKey: currencyKey),
+            CoinTicker.make(symbol: "symbol1", price: "10", contract: "contract1", currencyKey: currencyKey),
+            CoinTicker.make(symbol: "symbol2", price: "20", contract: "contract2", currencyKey: currencyKey),
+            CoinTicker.make(symbol: "symbol3", price: "30", contract: "contract3", currencyKey: currencyKey),
         ]
     }
 
     class func make2DuplicateCionTickersWithDifferentKey() -> [CoinTicker] {
         return [
-            CoinTicker.make(symbol: "same-symbol", contract: "same-contract-address", tickersKey: currencyKey, key: "old-key"),
-            CoinTicker.make(symbol: "same-symbol", contract: "same-contract-address", tickersKey: currencyKey),
+            CoinTicker.make(symbol: "same-symbol", contract: "same-contract-address", currencyKey: currencyKey, key: "old-key"),
+            CoinTicker.make(symbol: "same-symbol", contract: "same-contract-address", currencyKey: currencyKey),
         ]
     }
 }

--- a/TrustTests/Tokens/TokensDataStoreTest.swift
+++ b/TrustTests/Tokens/TokensDataStoreTest.swift
@@ -39,7 +39,7 @@ class TokensDataStoreTest: XCTestCase {
         XCTAssertEqual(0, tokensDataStore.tickers().count)
 
         let coinTickers = [
-            CoinTicker(symbol: "", price: "", percent_change_24h: "", contract: "", tickersKey: CoinTickerKeyFactory.makeCurrencyKey(for: Config.make()))
+            CoinTicker(symbol: "", price: "", percent_change_24h: "", contract: "", tickersKey: CoinTickerKeyMaker.makeCurrencyKey(for: Config.make()))
         ]
 
         tokensDataStore.saveTickers(tickers: coinTickers)

--- a/TrustTests/Tokens/TokensDataStoreTest.swift
+++ b/TrustTests/Tokens/TokensDataStoreTest.swift
@@ -11,14 +11,13 @@ class TokensDataStoreTest: XCTestCase {
         super.setUp()
 
         let config = Config.make()
-        let tickersKey = config.tickersKey
-
+        let currencyKey = CoinTickerKeyFactory.makeCurrencyKey(for: config)
         tokensDataStore = TokensDataStore(realm: .make(), config: config)
 
         coinTickers = [
-            CoinTicker(symbol: "symbol1", price: "10", percent_change_24h: "percent_change_24h_1", contract: "contract1", tickersKey: tickersKey),
-            CoinTicker(symbol: "symbol2", price: "20", percent_change_24h: "percent_change_24h_2", contract: "contract2", tickersKey: tickersKey),
-            CoinTicker(symbol: "symbol3", price: "30", percent_change_24h: "percent_change_24h_3", contract: "contract3", tickersKey: tickersKey),
+            CoinTicker(symbol: "symbol1", price: "10", percent_change_24h: "percent_change_24h_1", contract: "contract1", tickersKey: currencyKey),
+            CoinTicker(symbol: "symbol2", price: "20", percent_change_24h: "percent_change_24h_2", contract: "contract2", tickersKey: currencyKey),
+            CoinTicker(symbol: "symbol3", price: "30", percent_change_24h: "percent_change_24h_3", contract: "contract3", tickersKey: currencyKey),
         ]
     }
 
@@ -55,7 +54,7 @@ class TokensDataStoreTest: XCTestCase {
         XCTAssertEqual(0, tokensDataStore.tickers().count)
 
         let coinTickers = [
-            CoinTicker(symbol: "", price: "", percent_change_24h: "", contract: "", tickersKey: tokensDataStore.config.tickersKey)
+            CoinTicker(symbol: "", price: "", percent_change_24h: "", contract: "", tickersKey: CoinTickerKeyFactory.makeCurrencyKey(for: Config.make()))
         ]
 
         tokensDataStore.saveTickers(tickers: coinTickers)
@@ -100,17 +99,16 @@ class TokensDataStoreTest: XCTestCase {
 
     // This test checks that even the key generation algorithm changes, coinTicker(for:) still can pick up the correct CoinTicker object without needing to delete the old CoinTicker records since they have old key.
     func testGetCoinTickerForAParticularToken() {
-        let config = Config.make()
-        let tickersKey = config.tickersKey
+        let currencyKey = CoinTickerKeyFactory.makeCurrencyKey(for: Config.make())
 
         let coinTickersThatHaveSameFieldsButDifferentKey: [CoinTicker] = [
             {
-                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: tickersKey)
+                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: currencyKey)
                 coinTicker.key = "old-key"
                 return coinTicker
             }(),
             {
-                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: tickersKey)
+                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: currencyKey)
                 return coinTicker
             }()
         ]

--- a/TrustTests/Tokens/TokensDataStoreTest.swift
+++ b/TrustTests/Tokens/TokensDataStoreTest.swift
@@ -22,7 +22,7 @@ class TokensDataStoreTest: XCTestCase {
 
         do {
             try tokensDataStore.realm.write {
-                tokensDataStore.realm.add(CoinTicker.make(tickersKey: "This is a ticker currency key that does not match anyone"), update: true)
+                tokensDataStore.realm.add(CoinTicker.make(currencyKey: "This is a ticker currency key that does not match anyone"), update: true)
             }
         } catch let error {
             print(error.localizedDescription)
@@ -32,7 +32,7 @@ class TokensDataStoreTest: XCTestCase {
         XCTAssertEqual(0, tokensDataStore.tickers().count)
 
         let coinTickers = [
-            CoinTicker.make(tickersKey: CoinTickerKeyMaker.makeCurrencyKey(for: Config.make()))
+            CoinTicker.make(currencyKey: CoinTickerKeyMaker.makeCurrencyKey(for: Config.make()))
         ]
 
         tokensDataStore.saveTickers(tickers: coinTickers)

--- a/TrustTests/Tokens/TokensDataStoreTest.swift
+++ b/TrustTests/Tokens/TokensDataStoreTest.swift
@@ -4,27 +4,12 @@ import XCTest
 @testable import Trust
 
 class TokensDataStoreTest: XCTestCase {
-    var tokensDataStore: TokensDataStore!
-    var coinTickers: [CoinTicker]!
-
-    override func setUp() {
-        super.setUp()
-
-        let config = Config.make()
-        let currencyKey = CoinTickerKeyFactory.makeCurrencyKey(for: config)
-        tokensDataStore = TokensDataStore(realm: .make(), config: config)
-
-        coinTickers = [
-            CoinTicker(symbol: "symbol1", price: "10", percent_change_24h: "percent_change_24h_1", contract: "contract1", tickersKey: currencyKey),
-            CoinTicker(symbol: "symbol2", price: "20", percent_change_24h: "percent_change_24h_2", contract: "contract2", tickersKey: currencyKey),
-            CoinTicker(symbol: "symbol3", price: "30", percent_change_24h: "percent_change_24h_3", contract: "contract3", tickersKey: currencyKey),
-        ]
-    }
+    var tokensDataStore = TokensDataStore(realm: .make(), config: .make())
 
     func testGetAndSetTickers() {
         XCTAssertEqual(0, tokensDataStore.tickers().count)
 
-        tokensDataStore.saveTickers(tickers: coinTickers)
+        tokensDataStore.saveTickers(tickers: FakeCoinTickerFactory.make3UniqueCionTickers())
         
         let returnedCoinTickers = tokensDataStore.tickers()
         
@@ -75,6 +60,8 @@ class TokensDataStoreTest: XCTestCase {
             value: "10000"
         )
 
+        let coinTickers = FakeCoinTickerFactory.make3UniqueCionTickers()
+
         XCTAssertEqual(1000.00, tokensDataStore.getBalance(for: tokenObject, with: coinTickers))
 
         XCTAssertEqual(0.00, tokensDataStore.getBalance(for: tokenObject, with: [CoinTicker(price: "", contract: "contract1")]))
@@ -99,21 +86,7 @@ class TokensDataStoreTest: XCTestCase {
 
     // This test checks that even the key generation algorithm changes, coinTicker(for:) still can pick up the correct CoinTicker object without needing to delete the old CoinTicker records since they have old key.
     func testGetCoinTickerForAParticularToken() {
-        let currencyKey = CoinTickerKeyFactory.makeCurrencyKey(for: Config.make())
-
-        let coinTickersThatHaveSameFieldsButDifferentKey: [CoinTicker] = [
-            {
-                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: currencyKey)
-                coinTicker.key = "old-key"
-                return coinTicker
-            }(),
-            {
-                let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: currencyKey)
-                return coinTicker
-            }()
-        ]
-
-        tokensDataStore.saveTickers(tickers: coinTickersThatHaveSameFieldsButDifferentKey)
+        tokensDataStore.saveTickers(tickers: FakeCoinTickerFactory.make2DuplicateCionTickersWithDifferentKey())
 
         let token: TokenObject = {
             let token = TokenObject()

--- a/TrustTests/Tokens/TokensDataStoreTest.swift
+++ b/TrustTests/Tokens/TokensDataStoreTest.swift
@@ -4,17 +4,14 @@ import XCTest
 @testable import Trust
 
 class TokensDataStoreTest: XCTestCase {
-    var config: Config!
-    var tickersKey: String!
-
     var tokensDataStore: TokensDataStore!
     var coinTickers: [CoinTicker]!
 
     override func setUp() {
         super.setUp()
 
-        config = Config.make()
-        tickersKey = config.tickersKey
+        let config = Config.make()
+        let tickersKey = config.tickersKey
 
         tokensDataStore = TokensDataStore(realm: .make(), config: config)
 
@@ -101,8 +98,11 @@ class TokensDataStoreTest: XCTestCase {
         XCTAssertEqual(0.00, tokensDataStore.getBalance(for: tokenObject, with: coinTickers))
     }
 
+    // This test checks that even the key generation algorithm changes, coinTicker(for:) still can pick up the correct CoinTicker object without needing to delete the old CoinTicker records since they have old key.
     func testGetCoinTickerForAParticularToken() {
-        // This test checks that even the key generation algorithm changes, coinTicker(for:) still can pick up the correct CoinTicker object without needing to delete the old CoinTicker records since they have old key.
+        let config = Config.make()
+        let tickersKey = config.tickersKey
+
         let coinTickersThatHaveSameFieldsButDifferentKey: [CoinTicker] = [
             {
                 let coinTicker = CoinTicker(symbol: "same-symbol", price: "", percent_change_24h: "", contract: "same-contract-address", tickersKey: tickersKey)

--- a/TrustTests/Tokens/TokensDataStoreTest.swift
+++ b/TrustTests/Tokens/TokensDataStoreTest.swift
@@ -21,15 +21,8 @@ class TokensDataStoreTest: XCTestCase {
         XCTAssertEqual(0, tokensDataStore.tickers().count)
 
         do {
-            let coinTicker = CoinTicker(
-                symbol: "",
-                price: "",
-                percent_change_24h: "",
-                contract: "",
-                tickersKey: "This is a tickers key that does not match anyone"
-            )
             try tokensDataStore.realm.write {
-                tokensDataStore.realm.add(coinTicker, update: true)
+                tokensDataStore.realm.add(CoinTicker.make(tickersKey: "This is a ticker currency key that does not match anyone"), update: true)
             }
         } catch let error {
             print(error.localizedDescription)
@@ -39,7 +32,7 @@ class TokensDataStoreTest: XCTestCase {
         XCTAssertEqual(0, tokensDataStore.tickers().count)
 
         let coinTickers = [
-            CoinTicker(symbol: "", price: "", percent_change_24h: "", contract: "", tickersKey: CoinTickerKeyMaker.makeCurrencyKey(for: Config.make()))
+            CoinTicker.make(tickersKey: CoinTickerKeyMaker.makeCurrencyKey(for: Config.make()))
         ]
 
         tokensDataStore.saveTickers(tickers: coinTickers)


### PR DESCRIPTION
- fix an issue where duplicate CoinTicker records (the ones with old key) caused Token balance being incorrect