### PR TITLE
Bug/tokens separators

### DIFF
--- a/Trust/Style/Styles.swift
+++ b/Trust/Style/Styles.swift
@@ -39,6 +39,7 @@ struct StyleLayout {
     struct TableView {
         static let heightForHeaderInSection: CGFloat = 30
         static let separatorColor = UIColor(hex: "d7d7d7")
+        static let separatorHeigh: CGFloat = 0.5
     }
 
     struct CollectibleView {

--- a/Trust/Style/Styles.swift
+++ b/Trust/Style/Styles.swift
@@ -40,6 +40,11 @@ struct StyleLayout {
         static let heightForHeaderInSection: CGFloat = 30
         static let separatorColor = UIColor(hex: "d7d7d7")
         static let separatorHeight: CGFloat = 0.5
+
+        static func showSeparator(for tableView: UITableView, and index: IndexPath) -> Bool {
+            let numberOfRows = tableView.numberOfRows(inSection: index.section)
+            return index.row == numberOfRows - 1
+        }
     }
 
     struct CollectibleView {

--- a/Trust/Style/Styles.swift
+++ b/Trust/Style/Styles.swift
@@ -39,7 +39,7 @@ struct StyleLayout {
     struct TableView {
         static let heightForHeaderInSection: CGFloat = 30
         static let separatorColor = UIColor(hex: "d7d7d7")
-        static let separatorHeigh: CGFloat = 0.5
+        static let separatorHeight: CGFloat = 0.5
     }
 
     struct CollectibleView {

--- a/Trust/Tokens/ViewControllers/SearchTokenResultsController.swift
+++ b/Trust/Tokens/ViewControllers/SearchTokenResultsController.swift
@@ -39,6 +39,7 @@ class SearchTokenResultsController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.tableView.separatorStyle = .none
         configureTableView()
     }
 

--- a/Trust/Tokens/ViewControllers/TokenViewController.swift
+++ b/Trust/Tokens/ViewControllers/TokenViewController.swift
@@ -142,11 +142,6 @@ class TokenViewController: UIViewController {
         loadingView = LoadingView(insets: insets)
         emptyView = TransactionsEmptyView(insets: insets)
     }
-
-    private func showSeparator(for index: IndexPath) -> Bool {
-        let numberOfRows = tableView.numberOfRows(inSection: index.section)
-        return index.row == numberOfRows - 1
-    }
 }
 
 extension TokenViewController: UITableViewDataSource, UITableViewDelegate {
@@ -156,7 +151,7 @@ extension TokenViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TransactionViewCell.identifier, for: indexPath) as! TransactionViewCell
-        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath), and: showSeparator(for: indexPath))
+        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath), and: StyleLayout.TableView.showSeparator(for: tableView, and: indexPath))
         return cell
     }
 

--- a/Trust/Tokens/ViewControllers/TokenViewController.swift
+++ b/Trust/Tokens/ViewControllers/TokenViewController.swift
@@ -141,6 +141,11 @@ class TokenViewController: UIViewController {
         loadingView = LoadingView(insets: insets)
         emptyView = TransactionsEmptyView(insets: insets)
     }
+
+    private func showSeparator(for index: IndexPath) -> Bool {
+        let numberOfRows = tableView.numberOfRows(inSection: index.section)
+        return index.row == numberOfRows - 1
+    }
 }
 
 extension TokenViewController: UITableViewDataSource, UITableViewDelegate {
@@ -150,7 +155,7 @@ extension TokenViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TransactionViewCell.identifier, for: indexPath) as! TransactionViewCell
-        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath))
+        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath), and: false)
         return cell
     }
 
@@ -168,7 +173,7 @@ extension TokenViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         delegate?.didPress(transaction: viewModel.item(for: indexPath.row, section: indexPath.section), in: self)
-        tableView.deselectRow(at: indexPath, animated: true)
+        tableView.deselectRow(at: indexPath, animated: showSeparator(for: indexPath))
     }
 }
 

--- a/Trust/Tokens/ViewControllers/TokenViewController.swift
+++ b/Trust/Tokens/ViewControllers/TokenViewController.swift
@@ -36,6 +36,7 @@ class TokenViewController: UIViewController {
         view.backgroundColor = .white
 
         tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.separatorStyle = .none
         tableView.dataSource = self
         tableView.delegate = self
         tableView.tableHeaderView = header
@@ -155,7 +156,7 @@ extension TokenViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TransactionViewCell.identifier, for: indexPath) as! TransactionViewCell
-        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath), and: false)
+        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath), and: showSeparator(for: indexPath))
         return cell
     }
 
@@ -173,7 +174,7 @@ extension TokenViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         delegate?.didPress(transaction: viewModel.item(for: indexPath.row, section: indexPath.section), in: self)
-        tableView.deselectRow(at: indexPath, animated: showSeparator(for: indexPath))
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 

--- a/Trust/Tokens/ViewControllers/TokensViewController.swift
+++ b/Trust/Tokens/ViewControllers/TokensViewController.swift
@@ -66,8 +66,7 @@ class TokensViewController: UIViewController {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.separatorStyle = .singleLine
-        tableView.separatorColor = StyleLayout.TableView.separatorColor
+        tableView.separatorStyle = .none
         tableView.backgroundColor = .white
         view.addSubview(tableView)
         view.addSubview(footerView)

--- a/Trust/Tokens/Views/EditTokenTableViewCell.xib
+++ b/Trust/Tokens/Views/EditTokenTableViewCell.xib
@@ -46,9 +46,6 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="Su7-1W-bDk" firstAttribute="top" secondItem="gzC-hL-qRv" secondAttribute="bottom" constant="4" id="PQc-8k-3ip"/>
-                                </constraints>
                             </stackView>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Uf5-TC-p3g">
                                 <rect key="frame" x="239" y="10.5" width="51" height="31"/>
@@ -62,10 +59,20 @@
                             <constraint firstAttribute="bottom" secondItem="fRy-j2-9ES" secondAttribute="bottom" id="sQQ-18-ZYL"/>
                         </constraints>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PFP-IJ-Dn3">
+                        <rect key="frame" x="83" y="79" width="236" height="1"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="mJt-Lw-6BA"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="d5W-Lo-p3o" secondAttribute="trailing" constant="15" id="0eN-uy-pSI"/>
+                    <constraint firstItem="PFP-IJ-Dn3" firstAttribute="leading" secondItem="fRy-j2-9ES" secondAttribute="leading" id="JYz-Od-oxu"/>
                     <constraint firstItem="d5W-Lo-p3o" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Tdu-SU-ud4"/>
+                    <constraint firstAttribute="trailing" secondItem="PFP-IJ-Dn3" secondAttribute="trailing" id="aHR-aW-AjX"/>
+                    <constraint firstAttribute="bottom" secondItem="PFP-IJ-Dn3" secondAttribute="bottom" id="iPM-NN-4Wg"/>
                     <constraint firstItem="d5W-Lo-p3o" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="vlf-YR-icm"/>
                 </constraints>
             </tableViewCellContentView>
@@ -77,7 +84,7 @@
                 <outlet property="tokenImageView" destination="Tfc-cq-2hm" id="QtY-sC-dhw"/>
                 <outlet property="tokenLabel" destination="gzC-hL-qRv" id="cHh-cJ-bga"/>
             </connections>
-            <point key="canvasLocation" x="33.5" y="72"/>
+            <point key="canvasLocation" x="-204.5" y="95"/>
         </tableViewCell>
     </objects>
 </document>

--- a/Trust/Tokens/Views/EditTokenTableViewCell.xib
+++ b/Trust/Tokens/Views/EditTokenTableViewCell.xib
@@ -61,7 +61,7 @@
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PFP-IJ-Dn3">
                         <rect key="frame" x="83" y="79" width="236" height="1"/>
-                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" red="0.84313725490196079" green="0.84313725490196079" blue="0.84313725490196079" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="mJt-Lw-6BA"/>
                         </constraints>

--- a/Trust/Tokens/Views/TokenViewCell.swift
+++ b/Trust/Tokens/Views/TokenViewCell.swift
@@ -82,7 +82,7 @@ class TokenViewCell: UITableViewCell {
             stackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
             separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             separatorView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
-            separatorView.heightAnchor.constraint(equalToConstant: StyleLayout.TableView.separatorHeigh),
+            separatorView.heightAnchor.constraint(equalToConstant: StyleLayout.TableView.separatorHeight),
             separatorView.leftAnchor.constraint(equalTo: leftStackView.leftAnchor),
         ])
     }

--- a/Trust/Tokens/Views/TokenViewCell.swift
+++ b/Trust/Tokens/Views/TokenViewCell.swift
@@ -13,6 +13,7 @@ class TokenViewCell: UITableViewCell {
     let currencyAmountLabel = UILabel()
     let symbolImageView = TokenImageView()
     let percentChange = UILabel()
+    let separatorView = UIView()
 
     private struct Layout {
         static let stackVericalOffset: CGFloat = 10
@@ -37,6 +38,9 @@ class TokenViewCell: UITableViewCell {
 
         currencyAmountLabel.translatesAutoresizingMaskIntoConstraints = false
         currencyAmountLabel.textAlignment = .right
+
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        separatorView.backgroundColor = StyleLayout.TableView.separatorColor
 
         let leftStackView = UIStackView(arrangedSubviews: [titleLabel])
         leftStackView.translatesAutoresizingMaskIntoConstraints = false
@@ -67,6 +71,7 @@ class TokenViewCell: UITableViewCell {
         stackView.setContentHuggingPriority(.required, for: .horizontal)
 
         contentView.addSubview(stackView)
+        contentView.addSubview(separatorView)
 
         NSLayoutConstraint.activate([
             symbolImageView.widthAnchor.constraint(equalToConstant: TokensLayout.cell.imageSize),
@@ -75,6 +80,10 @@ class TokenViewCell: UITableViewCell {
             stackView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
             stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Layout.stackVericalOffset),
             stackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            separatorView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: StyleLayout.TableView.separatorHeigh),
+            separatorView.leftAnchor.constraint(equalTo: symbolImageView.rightAnchor),
         ])
 
         separatorInset = UIEdgeInsets(

--- a/Trust/Tokens/Views/TokenViewCell.swift
+++ b/Trust/Tokens/Views/TokenViewCell.swift
@@ -83,14 +83,8 @@ class TokenViewCell: UITableViewCell {
             separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             separatorView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
             separatorView.heightAnchor.constraint(equalToConstant: StyleLayout.TableView.separatorHeigh),
-            separatorView.leftAnchor.constraint(equalTo: symbolImageView.rightAnchor),
+            separatorView.leftAnchor.constraint(equalTo: leftStackView.leftAnchor),
         ])
-
-        separatorInset = UIEdgeInsets(
-            top: 0,
-            left: TokensLayout.tableView.layoutInsets.left - contentView.layoutInsets.left - layoutInsets.left,
-            bottom: 0, right: 0
-        )
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Trust/Transactions/ViewControllers/TransactionsViewController.swift
+++ b/Trust/Transactions/ViewControllers/TransactionsViewController.swift
@@ -40,6 +40,7 @@ class TransactionsViewController: UIViewController {
         view.backgroundColor = TransactionsViewModel.backgroundColor
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
+        tableView.separatorStyle = .none
         tableView.dataSource = self
         view.addSubview(tableView)
         tableView.register(TransactionViewCell.self, forCellReuseIdentifier: TransactionViewCell.identifier)
@@ -149,6 +150,11 @@ class TransactionsViewController: UIViewController {
         }, selector: #selector(Operation.main), userInfo: nil, repeats: true)
     }
 
+    private func showSeparator(for index: IndexPath) -> Bool {
+        let numberOfRows = tableView.numberOfRows(inSection: index.section)
+        return index.row == numberOfRows - 1
+    }
+
     deinit {
         NotificationCenter.default.removeObserver(self)
         viewModel.invalidateTransactionsObservation()
@@ -175,7 +181,7 @@ extension TransactionsViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TransactionViewCell.identifier, for: indexPath) as! TransactionViewCell
-        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath))
+        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath), and: showSeparator(for: indexPath))
         return cell
     }
 

--- a/Trust/Transactions/ViewControllers/TransactionsViewController.swift
+++ b/Trust/Transactions/ViewControllers/TransactionsViewController.swift
@@ -150,11 +150,6 @@ class TransactionsViewController: UIViewController {
         }, selector: #selector(Operation.main), userInfo: nil, repeats: true)
     }
 
-    private func showSeparator(for index: IndexPath) -> Bool {
-        let numberOfRows = tableView.numberOfRows(inSection: index.section)
-        return index.row == numberOfRows - 1
-    }
-
     deinit {
         NotificationCenter.default.removeObserver(self)
         viewModel.invalidateTransactionsObservation()
@@ -181,7 +176,7 @@ extension TransactionsViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TransactionViewCell.identifier, for: indexPath) as! TransactionViewCell
-        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath), and: showSeparator(for: indexPath))
+        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath), and: StyleLayout.TableView.showSeparator(for: tableView, and: indexPath))
         return cell
     }
 

--- a/Trust/Transactions/Views/TransactionViewCell.swift
+++ b/Trust/Transactions/Views/TransactionViewCell.swift
@@ -6,10 +6,11 @@ class TransactionViewCell: UITableViewCell {
 
     static let identifier = "TransactionTableViewCell"
 
-    let statusImageView = UIImageView()
-    let titleLabel = UILabel()
-    let amountLabel = UILabel()
-    let subTitleLabel = UILabel()
+    private let statusImageView = UIImageView()
+    private let titleLabel = UILabel()
+    private let amountLabel = UILabel()
+    private let subTitleLabel = UILabel()
+    private let separatorView = UIView()
 
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -24,6 +25,9 @@ class TransactionViewCell: UITableViewCell {
 
         amountLabel.textAlignment = .right
         amountLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        separatorView.backgroundColor = StyleLayout.TableView.separatorColor
 
         let titlesStackView = UIStackView(arrangedSubviews: [titleLabel, subTitleLabel])
         titlesStackView.translatesAutoresizingMaskIntoConstraints = false
@@ -57,6 +61,7 @@ class TransactionViewCell: UITableViewCell {
         stackView.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)
 
         contentView.addSubview(stackView)
+        contentView.addSubview(separatorView)
 
         NSLayoutConstraint.activate([
             statusImageView.widthAnchor.constraint(lessThanOrEqualToConstant: 26),
@@ -64,20 +69,18 @@ class TransactionViewCell: UITableViewCell {
             stackView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
             stackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -StyleLayout.sideMargin),
             stackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            separatorView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: StyleLayout.TableView.separatorHeigh),
+            separatorView.leftAnchor.constraint(equalTo: titlesStackView.leftAnchor),
         ])
-
-        separatorInset = UIEdgeInsets(
-            top: 0,
-            left: TransactionsLayout.tableView.layoutInsets.left - contentView.layoutInsets.left - layoutInsets.left,
-            bottom: 0, right: 0
-        )
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(viewModel: TransactionCellViewModel) {
+    func configure(viewModel: TransactionCellViewModel, and separatorNeeded: Bool) {
 
         statusImageView.image = viewModel.statusImage
 
@@ -92,5 +95,6 @@ class TransactionViewCell: UITableViewCell {
         amountLabel.textColor = viewModel.amountTextColor
 
         backgroundColor = viewModel.backgroundColor
+        separatorView.isHidden = separatorNeeded
     }
 }

--- a/Trust/Transactions/Views/TransactionViewCell.swift
+++ b/Trust/Transactions/Views/TransactionViewCell.swift
@@ -71,7 +71,7 @@ class TransactionViewCell: UITableViewCell {
             stackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
             separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             separatorView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
-            separatorView.heightAnchor.constraint(equalToConstant: StyleLayout.TableView.separatorHeigh),
+            separatorView.heightAnchor.constraint(equalToConstant: StyleLayout.TableView.separatorHeight),
             separatorView.leftAnchor.constraint(equalTo: titlesStackView.leftAnchor),
         ])
     }


### PR DESCRIPTION
- Update of the cell style
- Add new view to show separator
- Remove of the calculation for intents (UIKit constraints will do it for as)
- Set proper offset of the separator.

In this fix separators will be same in all iOS and devices versions. 