### PR TITLE
Set priority for the spacerWidth view.

### DIFF
--- a/Trust/Extensions/UIView.swift
+++ b/Trust/Extensions/UIView.swift
@@ -40,7 +40,7 @@ extension UIView {
         return view
     }
 
-    static func spacerWidth(_ width: CGFloat = 1, backgroundColor: UIColor = .clear, alpha: CGFloat = 1) -> UIView {
+    static func spacerWidth(_ width: CGFloat = 1, backgroundColor: UIColor = .clear, alpha: CGFloat = 1, lowPriority: Bool = false) -> UIView {
         let view = UIView(frame: .zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = backgroundColor
@@ -48,7 +48,7 @@ extension UIView {
 
         let width = view.widthAnchor.constraint(equalToConstant: width)
         width.isActive = true
-        width.priority = UILayoutPriority(rawValue: 999)
+        width.priority = lowPriority ? UILayoutPriority(rawValue: 999) : UILayoutPriority(rawValue: 1000)
 
         return view
     }

--- a/Trust/Extensions/UIView.swift
+++ b/Trust/Extensions/UIView.swift
@@ -40,7 +40,7 @@ extension UIView {
         return view
     }
 
-    static func spacerWidth(_ width: CGFloat = 1, backgroundColor: UIColor = .clear, alpha: CGFloat = 1, lowPriority: Bool = false) -> UIView {
+    static func spacerWidth(_ width: CGFloat = 1, backgroundColor: UIColor = .clear, alpha: CGFloat = 1, priority: UILayoutPriority = UILayoutPriority(rawValue: 1000)) -> UIView {
         let view = UIView(frame: .zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = backgroundColor
@@ -48,7 +48,7 @@ extension UIView {
 
         let width = view.widthAnchor.constraint(equalToConstant: width)
         width.isActive = true
-        width.priority = lowPriority ? UILayoutPriority(rawValue: 999) : UILayoutPriority(rawValue: 1000)
+        width.priority = priority
 
         return view
     }

--- a/Trust/Tokens/Views/TokenHeaderView.swift
+++ b/Trust/Tokens/Views/TokenHeaderView.swift
@@ -59,7 +59,7 @@ class TokenHeaderView: UIView {
         amountStack.translatesAutoresizingMaskIntoConstraints = false
         amountStack.axis = .horizontal
 
-        let marketPriceStack = UIStackView(arrangedSubviews: [fiatAmountLabel, .spacerWidth(5, backgroundColor: UIColor.clear, alpha: 0), percentChange])
+        let marketPriceStack = UIStackView(arrangedSubviews: [fiatAmountLabel, .spacerWidth(5, backgroundColor: UIColor.clear, alpha: 0, lowPriority: true), percentChange])
         marketPriceStack.translatesAutoresizingMaskIntoConstraints = false
         marketPriceStack.axis = .horizontal
         marketPriceStack.distribution = .equalSpacing

--- a/Trust/Tokens/Views/TokenHeaderView.swift
+++ b/Trust/Tokens/Views/TokenHeaderView.swift
@@ -59,7 +59,7 @@ class TokenHeaderView: UIView {
         amountStack.translatesAutoresizingMaskIntoConstraints = false
         amountStack.axis = .horizontal
 
-        let marketPriceStack = UIStackView(arrangedSubviews: [fiatAmountLabel, .spacerWidth(5, backgroundColor: UIColor.clear, alpha: 0, lowPriority: true), percentChange])
+        let marketPriceStack = UIStackView(arrangedSubviews: [fiatAmountLabel, .spacerWidth(5, backgroundColor: UIColor.clear, alpha: 0, priority: UILayoutPriority(rawValue: 999)), percentChange])
         marketPriceStack.translatesAutoresizingMaskIntoConstraints = false
         marketPriceStack.axis = .horizontal
         marketPriceStack.distribution = .equalSpacing


### PR DESCRIPTION
Fix for the spacerWidth method to return view with suitable priority to suspend warnings.