### PR TITLE
Browser memory fix

### DIFF
--- a/Trust/Browser/Coordinators/BrowserCoordinator.swift
+++ b/Trust/Browser/Coordinators/BrowserCoordinator.swift
@@ -174,6 +174,7 @@ class BrowserCoordinator: NSObject, Coordinator {
             case .failure:
                 self.rootViewController.browserViewController.notifyFinish(callbackID: callbackID, value: .failure(DAppError.cancelled))
             }
+            coordinator.didComplete = nil
             self.removeCoordinator(coordinator)
         }
         coordinator.delegate = self
@@ -307,6 +308,7 @@ extension BrowserCoordinator: BrowserViewControllerDelegate {
 
 extension BrowserCoordinator: SignMessageCoordinatorDelegate {
     func didCancel(in coordinator: SignMessageCoordinator) {
+        coordinator.didComplete = nil
         removeCoordinator(coordinator)
     }
 }

--- a/Trust/Core/Coordinators/LocalSchemeCoordinator.swift
+++ b/Trust/Core/Coordinators/LocalSchemeCoordinator.swift
@@ -46,6 +46,7 @@ class LocalSchemeCoordinator: Coordinator {
             case .failure:
                 completion(.failure(WalletError.cancelled))
             }
+            coordinator.didComplete = nil
             self.removeCoordinator(coordinator)
         }
         coordinator.delegate = self
@@ -100,6 +101,7 @@ class LocalSchemeCoordinator: Coordinator {
 extension LocalSchemeCoordinator: SignMessageCoordinatorDelegate {
     func didCancel(in coordinator: SignMessageCoordinator) {
         coordinator.navigationController.dismiss(animated: true, completion: nil)
+        coordinator.didComplete = nil
         delegate?.didCancel(in: self)
     }
 }

--- a/Trust/Core/Initializers/CrashReportInitializer.swift
+++ b/Trust/Core/Initializers/CrashReportInitializer.swift
@@ -9,6 +9,6 @@ struct CrashReportInitializer: Initializer {
     func perform() {
         guard !isDebug else { return }
 
-        Fabric.with([Crashlytics.self, Answers.self])
+        Fabric.with([Crashlytics.self])
     }
 }

--- a/Trust/Core/Initializers/CrashReportInitializer.swift
+++ b/Trust/Core/Initializers/CrashReportInitializer.swift
@@ -9,6 +9,6 @@ struct CrashReportInitializer: Initializer {
     func perform() {
         guard !isDebug else { return }
 
-        Fabric.with([Crashlytics.self])
+        Fabric.with([Crashlytics.self, Answers.self])
     }
 }


### PR DESCRIPTION
- Remove SignMessageCoordinator from stack.
- Remove unused class.