### PR TITLE
Move to POST instead of DELETE on notifications unregister API call

### DIFF
--- a/Trust/EtherClient/TrustClient/TrustClient.swift
+++ b/Trust/EtherClient/TrustClient/TrustClient.swift
@@ -45,7 +45,7 @@ extension TrustService: TargetType {
         case .getTokens: return .get
         case .getTransaction: return .get
         case .register: return .post
-        case .unregister: return .delete
+        case .unregister: return .post
         case .marketplace: return .get
         case .assets: return .get
         case .search: return .get

--- a/Trust/Settings/Coordinators/PushNotificationsRegistrar.swift
+++ b/Trust/Settings/Coordinators/PushNotificationsRegistrar.swift
@@ -33,19 +33,7 @@ class PushNotificationsRegistrar {
             preferences: NotificationsViewController.getPreferences()
         )
 
-        trustProvider.request(.unregister(device: device)) { response in
-            guard response.error == nil else {
-                return
-            }
-            if let statusCode = response.value?.statusCode {
-                switch statusCode {
-                case 200:
-                    break
-                default:
-                    print("Error - device unregister - Status Code \(statusCode). Operation could not be completed.")
-                }
-            }
-        }
+        trustProvider.request(.unregister(device: device)) { _ in }
 
         UIApplication.shared.unregisterForRemoteNotifications()
     }

--- a/Trust/Settings/Coordinators/PushNotificationsRegistrar.swift
+++ b/Trust/Settings/Coordinators/PushNotificationsRegistrar.swift
@@ -33,7 +33,20 @@ class PushNotificationsRegistrar {
             preferences: NotificationsViewController.getPreferences()
         )
 
-        trustProvider.request(.unregister(device: device)) { _ in }
+        trustProvider.request(.unregister(device: device)) { response in
+            guard response.error == nil else {
+                return
+            }
+            if let statusCode = response.value?.statusCode {
+                switch statusCode {
+                case 200:
+                    break
+                default:
+                    print("Error - device unregister - Status Code \(statusCode). Operation could not be completed.")
+                }
+            }
+        }
+
         UIApplication.shared.unregisterForRemoteNotifications()
     }
 


### PR DESCRIPTION
Referencing this https://github.com/TrustWallet/trust-wallet-ios/issues/763 ticket. 