### PR TITLE
Cookies usage update

### DIFF
--- a/Trust/AppCoordinator.swift
+++ b/Trust/AppCoordinator.swift
@@ -100,11 +100,19 @@ class AppCoordinator: NSObject, Coordinator {
         navigationController.viewControllers = [welcomeViewController]
     }
 
+    func applicationWillResignActive() {
+        inCoordinator?.cookiesStore.syncCookies()
+    }
+
+    func applicationDidBecomeActive() {
+        inCoordinator?.cookiesStore.load()
+    }
+
     @objc func reset() {
         lock.deletePasscode()
         pushNotificationRegistrar.unregister()
         coordinators.removeAll()
-        CookiesStore.delete()
+        inCoordinator?.cookiesStore.delete()
         navigationController.dismiss(animated: true, completion: nil)
         resetToWelcomeScreen()
     }

--- a/Trust/AppDelegate.swift
+++ b/Trust/AppDelegate.swift
@@ -41,12 +41,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     func applicationWillResignActive(_ application: UIApplication) {
         protectionCoordinator.applicationWillResignActive()
         Lock().setAutoLockTime()
-        CookiesStore.save()
+        coordinator.applicationWillResignActive()
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
         protectionCoordinator.applicationDidBecomeActive()
-        CookiesStore.load()
+        coordinator.applicationDidBecomeActive()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {

--- a/Trust/Browser/Storage/CookiesStore.swift
+++ b/Trust/Browser/Storage/CookiesStore.swift
@@ -11,22 +11,30 @@ enum CookiesStoreError: LocalizedError {
 
 class CookiesStore {
 
-    private static let webKitStorage = WKWebsiteDataStore.default()
-    private static let httpCookieStorage = HTTPCookieStorage.shared
-    private static let keychain = KeychainSwift(keyPrefix: Constants.keychainKeyPrefix)
+    private let webKitStorage = WKWebsiteDataStore.default()
+    private let httpCookieStorage = HTTPCookieStorage.shared
+    private let keychain = KeychainSwift(keyPrefix: Constants.keychainKeyPrefix)
 
-    private static let cookiesKey = "cookies"
+    private var wallet: WalletInfo
+    private var key: String
+    private var config = Config()
 
-    static func save() {
+    init(wallet: WalletInfo) {
+        self.wallet = wallet
+        self.key = wallet.wallet.address.eip55String + "\(config.chainID)"
+        load()
+    }
+
+    func syncCookies() {
         firstly {
             fetchCookies()
-        }.done { cookies in
-            save(cookies: cookies)
+        }.done { [weak self] cookies in
+            self?.save(cookies: cookies)
         }
     }
 
-    static func load() {
-        guard let encodedData = keychain.getData(cookiesKey), let decodedArray = NSKeyedUnarchiver.unarchiveObject(with: encodedData) as? [HTTPCookie] else { return }
+    func load() {
+        guard let encodedData = keychain.getData(key), let decodedArray = NSKeyedUnarchiver.unarchiveObject(with: encodedData) as? [HTTPCookie] else { return }
         decodedArray.forEach { cookie in
             if #available(iOS 11.0, *) {
                 webKitStorage.httpCookieStore.setCookie(cookie, completionHandler: nil)
@@ -36,16 +44,16 @@ class CookiesStore {
         }
     }
 
-    static func delete() {
-        keychain.delete(cookiesKey)
+    func delete() {
+        keychain.delete(key)
     }
 
-    private static func save(cookies: [HTTPCookie]) {
+    private func save(cookies: [HTTPCookie]) {
         let data = NSKeyedArchiver.archivedData(withRootObject: cookies)
-        keychain.set(data, forKey: cookiesKey)
+        keychain.set(data, forKey: key)
     }
 
-    private static func fetchCookies() -> Promise<[HTTPCookie]> {
+    private func fetchCookies() -> Promise<[HTTPCookie]> {
         return Promise { seal in
             if #available(iOS 11.0, *) {
                 webKitStorage.httpCookieStore.getAllCookies { cookies in

--- a/Trust/Browser/Storage/CookiesStore.swift
+++ b/Trust/Browser/Storage/CookiesStore.swift
@@ -22,11 +22,12 @@ class CookiesStore {
         load()
     }
 
-    func syncCookies() {
+    func syncCookies(completion: (() -> Void)? = nil) {
         firstly {
             fetchCookies()
         }.done { [weak self] cookies in
             self?.save(cookies: cookies)
+            completion?()
         }
     }
 

--- a/Trust/Browser/Storage/CookiesStore.swift
+++ b/Trust/Browser/Storage/CookiesStore.swift
@@ -15,13 +15,10 @@ class CookiesStore {
     private let httpCookieStorage = HTTPCookieStorage.shared
     private let keychain = KeychainSwift(keyPrefix: Constants.keychainKeyPrefix)
 
-    private var wallet: WalletInfo
     private var key: String
-    private var config = Config()
 
-    init(wallet: WalletInfo) {
-        self.wallet = wallet
-        self.key = wallet.wallet.address.eip55String + "\(config.chainID)"
+    init(sessionKey: String) {
+        self.key = sessionKey
         load()
     }
 

--- a/Trust/InCoordinator.swift
+++ b/Trust/InCoordinator.swift
@@ -143,7 +143,7 @@ class InCoordinator: Coordinator {
         walletCoordinator.start()
         addCoordinator(walletCoordinator)
 
-        cookiesStore = CookiesStore(sessionKey: session.sessionID)
+        cookiesStore = CookiesStore(sessionKey: account.sessionID)
 
         let settingsCoordinator = SettingsCoordinator(
             keystore: keystore,

--- a/Trust/InCoordinator.swift
+++ b/Trust/InCoordinator.swift
@@ -62,7 +62,7 @@ class InCoordinator: Coordinator {
         self.config = config
         self.appTracker = appTracker
         self.navigator = navigator
-        self.cookiesStore = CookiesStore(wallet: wallet)
+        self.cookiesStore = CookiesStore(sessionKey: wallet.sessionID)
         self.register(with: navigator)
     }
 
@@ -143,7 +143,7 @@ class InCoordinator: Coordinator {
         walletCoordinator.start()
         addCoordinator(walletCoordinator)
 
-        cookiesStore = CookiesStore(wallet: account)
+        cookiesStore = CookiesStore(sessionKey: session.sessionID)
 
         let settingsCoordinator = SettingsCoordinator(
             keystore: keystore,

--- a/Trust/InCoordinator.swift
+++ b/Trust/InCoordinator.swift
@@ -21,6 +21,7 @@ class InCoordinator: Coordinator {
     let config: Config
     let appTracker: AppTracker
     let navigator: Navigator
+    var cookiesStore: CookiesStore
     weak var delegate: InCoordinatorDelegate?
     var browserCoordinator: BrowserCoordinator? {
         return self.coordinators.compactMap { $0 as? BrowserCoordinator }.first
@@ -61,6 +62,7 @@ class InCoordinator: Coordinator {
         self.config = config
         self.appTracker = appTracker
         self.navigator = navigator
+        self.cookiesStore = CookiesStore(wallet: wallet)
         self.register(with: navigator)
     }
 
@@ -141,6 +143,10 @@ class InCoordinator: Coordinator {
         walletCoordinator.start()
         addCoordinator(walletCoordinator)
 
+        let walletStorage = WalletStorage(realm: realm)
+
+        cookiesStore = CookiesStore(wallet: account)
+
         let settingsCoordinator = SettingsCoordinator(
             keystore: keystore,
             session: session,
@@ -148,7 +154,8 @@ class InCoordinator: Coordinator {
             walletStorage: walletStorage,
             balanceCoordinator: balanceCoordinator,
             sharedRealm: sharedRealm,
-            ensManager: ENSManager(realm: realm, config: config)
+            ensManager: ENSManager(realm: realm, config: config),
+            cookiesStore: cookiesStore
         )
         settingsCoordinator.rootViewController.tabBarItem = viewModel.settingsBarItem
         settingsCoordinator.delegate = self
@@ -215,7 +222,6 @@ class InCoordinator: Coordinator {
         navigationController.dismiss(animated: false, completion: nil)
         coordinator.navigationController.dismiss(animated: true, completion: nil)
         coordinator.stop()
-        CookiesStore.delete()
         removeAllCoordinators()
         showTabBar(for: account)
     }

--- a/Trust/InCoordinator.swift
+++ b/Trust/InCoordinator.swift
@@ -143,8 +143,6 @@ class InCoordinator: Coordinator {
         walletCoordinator.start()
         addCoordinator(walletCoordinator)
 
-        let walletStorage = WalletStorage(realm: realm)
-
         cookiesStore = CookiesStore(wallet: account)
 
         let settingsCoordinator = SettingsCoordinator(

--- a/Trust/Settings/Coordinators/SettingsCoordinator.swift
+++ b/Trust/Settings/Coordinators/SettingsCoordinator.swift
@@ -44,8 +44,7 @@ class SettingsCoordinator: Coordinator {
             session: session,
             keystore: keystore,
             balanceCoordinator: balanceCoordinator,
-            accountsCoordinator: accountsCoordinator,
-            cookiesStore: cookiesStore
+            accountsCoordinator: accountsCoordinator
         )
         controller.delegate = self
         controller.modalPresentationStyle = .pageSheet
@@ -86,7 +85,13 @@ class SettingsCoordinator: Coordinator {
     }
 
     func restart(for wallet: Wallet) {
-        delegate?.didRestart(with: wallet, in: self)
+        guard let currentViewController = self.navigationController.viewControllers.last else { return }
+        currentViewController.displayLoading()
+        cookiesStore.syncCookies { [weak self] in
+            currentViewController.hideLoading(animated: false)
+            guard let strongSelf = self else { return }
+            strongSelf.delegate?.didRestart(with: wallet, in: strongSelf)
+        }
     }
 
     func cleadCache() {

--- a/Trust/Settings/Coordinators/SettingsCoordinator.swift
+++ b/Trust/Settings/Coordinators/SettingsCoordinator.swift
@@ -22,6 +22,7 @@ class SettingsCoordinator: Coordinator {
     let walletStorage: WalletStorage
     let balanceCoordinator: TokensBalanceService
     let ensManager: ENSManager
+    let cookiesStore: CookiesStore
     weak var delegate: SettingsCoordinatorDelegate?
     let pushNotificationsRegistrar = PushNotificationsRegistrar()
     var coordinators: [Coordinator] = []
@@ -43,7 +44,8 @@ class SettingsCoordinator: Coordinator {
             session: session,
             keystore: keystore,
             balanceCoordinator: balanceCoordinator,
-            accountsCoordinator: accountsCoordinator
+            accountsCoordinator: accountsCoordinator,
+            cookiesStore: cookiesStore
         )
         controller.delegate = self
         controller.modalPresentationStyle = .pageSheet
@@ -62,7 +64,8 @@ class SettingsCoordinator: Coordinator {
         walletStorage: WalletStorage,
         balanceCoordinator: TokensBalanceService,
         sharedRealm: Realm,
-        ensManager: ENSManager
+        ensManager: ENSManager,
+        cookiesStore: CookiesStore
     ) {
         self.navigationController = navigationController
         self.navigationController.modalPresentationStyle = .formSheet
@@ -73,6 +76,7 @@ class SettingsCoordinator: Coordinator {
         self.balanceCoordinator = balanceCoordinator
         self.sharedRealm = sharedRealm
         self.ensManager = ensManager
+        self.cookiesStore = cookiesStore
 
         addCoordinator(accountsCoordinator)
     }
@@ -157,7 +161,7 @@ extension SettingsCoordinator: SettingsViewControllerDelegate {
             delegate?.didPressURL(url, in: self)
         case .clearBrowserCache:
             cleadCache()
-            CookiesStore.delete()
+            cookiesStore.delete()
         }
     }
 }

--- a/Trust/Settings/ViewControllers/SettingsViewController.swift
+++ b/Trust/Settings/ViewControllers/SettingsViewController.swift
@@ -70,29 +70,24 @@ class SettingsViewController: FormViewController, Coordinator {
 
     let balanceCoordinator: TokensBalanceService
 
-    let cookiesStore: CookiesStore
-
     weak var accountsCoordinator: AccountsCoordinator?
 
     init(
         session: WalletSession,
         keystore: Keystore,
         balanceCoordinator: TokensBalanceService,
-        accountsCoordinator: AccountsCoordinator,
-        cookiesStore: CookiesStore
+        accountsCoordinator: AccountsCoordinator
     ) {
         self.session = session
         self.keystore = keystore
         self.balanceCoordinator = balanceCoordinator
         self.accountsCoordinator = accountsCoordinator
-        self.cookiesStore = cookiesStore
         super.init(nibName: nil, bundle: nil)
         self.chaineStateObservation()
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        cookiesStore.syncCookies()
         if let stateView = networkStateView {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: stateView)
         }

--- a/Trust/Settings/ViewControllers/SettingsViewController.swift
+++ b/Trust/Settings/ViewControllers/SettingsViewController.swift
@@ -70,24 +70,29 @@ class SettingsViewController: FormViewController, Coordinator {
 
     let balanceCoordinator: TokensBalanceService
 
+    let cookiesStore: CookiesStore
+
     weak var accountsCoordinator: AccountsCoordinator?
 
     init(
         session: WalletSession,
         keystore: Keystore,
         balanceCoordinator: TokensBalanceService,
-        accountsCoordinator: AccountsCoordinator
+        accountsCoordinator: AccountsCoordinator,
+        cookiesStore: CookiesStore
     ) {
         self.session = session
         self.keystore = keystore
         self.balanceCoordinator = balanceCoordinator
         self.accountsCoordinator = accountsCoordinator
+        self.cookiesStore = cookiesStore
         super.init(nibName: nil, bundle: nil)
         self.chaineStateObservation()
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        cookiesStore.syncCookies()
         if let stateView = networkStateView {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: stateView)
         }

--- a/Trust/Transactions/Storage/Session.swift
+++ b/Trust/Transactions/Storage/Session.swift
@@ -17,10 +17,6 @@ class WalletSession {
         return balanceCoordinator.balance
     }
 
-    var sessionID: String {
-        return "\(account.address.description.lowercased())-\(config.chainID)"
-    }
-
     var balanceViewModel: Subscribable<BalanceBaseViewModel> = Subscribable(nil)
     var nonceProvider: NonceProvider
 

--- a/Trust/Transactions/Types/TransactionOperation.swift
+++ b/Trust/Transactions/Types/TransactionOperation.swift
@@ -13,7 +13,7 @@ class TransactionOperation: TrustOperation {
     var transactionsHistory = [Transaction]()
 
     private lazy var tracker: TransactionsTracker = {
-        return TransactionsTracker(sessionID: self.session.sessionID)
+        return TransactionsTracker(sessionID: self.session.account.sessionID)
     }()
 
     init(

--- a/Trust/Wallet/Types/WalletInfo.swift
+++ b/Trust/Wallet/Types/WalletInfo.swift
@@ -25,3 +25,9 @@ extension WalletInfo: Equatable {
         return lhs.wallet.description == rhs.wallet.description
     }
 }
+
+extension WalletInfo {
+    var sessionID: String {
+        return "\(address.description.lowercased())-\(Config().chainID)"
+    }
+}

--- a/TrustTests/Settings/Coordinators/SettingsCoordinatorTests.swift
+++ b/TrustTests/Settings/Coordinators/SettingsCoordinatorTests.swift
@@ -15,7 +15,8 @@ class SettingsCoordinatorTests: XCTestCase {
             walletStorage: FakeWalletStorage(),
             balanceCoordinator: FakeGetBalanceCoordinator(),
             sharedRealm: .make(),
-            ensManager: ENSManager(realm: .make())
+            ensManager: ENSManager(realm: .make()),
+            cookiesStore: CookiesStore(wallet: .make())
         )
         storage.add([.make()])
         storage.updateTransactionSection()


### PR DESCRIPTION
Update usage of the cookies by:

- We have for each wallet + chainId specific cookies key.
- We have two points of cookies sync on app close and on settings screen.