### PR TITLE
Replace injection of the cell view model in more appropriate place.

### DIFF
--- a/Trust/Tokens/ViewControllers/TokensViewController.swift
+++ b/Trust/Tokens/ViewControllers/TokensViewController.swift
@@ -200,13 +200,15 @@ extension TokensViewController: UITableViewDelegate {
 extension TokensViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TokenViewCell.identifier, for: indexPath) as! TokenViewCell
-        cell.configure(viewModel: viewModel.cellViewModel(for: indexPath))
-        cell.contentView.isExclusiveTouch = true
         cell.isExclusiveTouch = true
         return cell
     }
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.tokens.count
+    }
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+       guard let tokenViewCell = cell as? TokenViewCell else { return }
+       tokenViewCell.configure(viewModel: viewModel.cellViewModel(for: indexPath))
     }
 }
 extension TokensViewController: TokensViewModelDelegate {


### PR DESCRIPTION
Based on the article about smooth scrolling we should bind data tableView:willDisplayCell:forRowAtIndexPath but not at cellForRowAtIndexPath.

Original source:
https://medium.com/ios-os-x-development/perfect-smooth-scrolling-in-uitableviews-fd609d5275a5