### PR TITLE
Balance calculation patch

### DIFF
--- a/Trust/Tokens/Storage/TokensDataStore.swift
+++ b/Trust/Tokens/Storage/TokensDataStore.swift
@@ -220,7 +220,7 @@ class TokensDataStore {
         }
     }
 
-    func getBalance(for address: Address, with value:BigInt, and decimals:Int) -> Double {
+    func getBalance(for address: Address, with value: BigInt, and decimals: Int) -> Double {
         guard let ticker = coinTicker(by: address),
             let amountInDecimal = EtherNumberFormatter.full.decimal(from: value, decimals: decimals),
             let price = Double(ticker.price) else {

--- a/Trust/Tokens/Storage/TokensDataStore.swift
+++ b/Trust/Tokens/Storage/TokensDataStore.swift
@@ -135,7 +135,7 @@ class TokensDataStore {
         try? realm.write {
             if let tokenObjects = tokens as? [TokenObject] {
                 let tokenObjectsWithBalance = tokenObjects.map { tokenObject -> TokenObject in
-                    tokenObject.balance = self.getBalance(for: tokenObject)
+                    tokenObject.balance = self.getBalance(for: tokenObject.address, with: tokenObject.valueBigInt, and: tokenObject.decimals)
                     return tokenObject
                 }
                 realm.add(tokenObjectsWithBalance, update: true)
@@ -164,7 +164,7 @@ class TokensDataStore {
     //Background update of the Realm model.
     func update(balance: BigInt, for address: Address) {
         if let token = getToken(for: address) {
-            let tokenBalance = self.getBalance(for: token)
+            let tokenBalance = getBalance(for: token.address, with: balance, and: token.decimals)
             self.realm.writeAsync(obj: token) { (realm, _ ) in
                 let update = self.objectToUpdate(for: (address, balance), tokenBalance: tokenBalance)
                 realm.create(TokenObject.self, value: update, update: true)
@@ -220,11 +220,9 @@ class TokensDataStore {
         }
     }
 
-    func getBalance(for token: TokenObject?) -> Double {
-        guard let token = token,
-            let ticker = coinTicker(by: token.address),
-            let amountInBigInt = BigInt(token.value),
-            let amountInDecimal = EtherNumberFormatter.full.decimal(from: amountInBigInt, decimals: token.decimals),
+    func getBalance(for address: Address, with value:BigInt, and decimals:Int) -> Double {
+        guard let ticker = coinTicker(by: address),
+            let amountInDecimal = EtherNumberFormatter.full.decimal(from: value, decimals: decimals),
             let price = Double(ticker.price) else {
             return TokenObject.DEFAULT_BALANCE
         }

--- a/TrustTests/Tokens/TokensDataStoreTest.swift
+++ b/TrustTests/Tokens/TokensDataStoreTest.swift
@@ -70,7 +70,7 @@ class TokensDataStoreTest: XCTestCase {
             value: "0"
         )
 
-        XCTAssertEqual(0.00, tokensDataStore.getBalance(for: tokenObject))
+        XCTAssertEqual(0.00, tokensDataStore.getBalance(for: tokenObject.address, with: tokenObject.valueBigInt, and: tokenObject.decimals))
     }
 
     // This test checks that even the key generation algorithm changes, coinTicker(for:) still can pick up the correct CoinTicker object without needing to delete the old CoinTicker records since they have old key.


### PR DESCRIPTION

Update flow now we update ui when all required data is presented.
Update balance calculation so now we will calculate right balance of the token.

@vikmeup I try to use our rule that we do not brake we just enchant existing solution.

Example of the work.

![ezgif com-optimize-2](https://user-images.githubusercontent.com/3758731/43233104-f4bd75a4-907c-11e8-9aca-95ad2b964041.gif)