### PR TITLE
Add generic passwork checker before sending transaction

### DIFF
--- a/Trust/Transfer/ViewControllers/ConfirmPaymentViewController.swift
+++ b/Trust/Transfer/ViewControllers/ConfirmPaymentViewController.swift
@@ -23,6 +23,9 @@ class ConfirmPaymentViewController: UIViewController {
     lazy var sendTransactionCoordinator = {
         return SendTransactionCoordinator(session: self.session, keystore: keystore, confirmType: confirmType, server: server)
     }()
+    lazy var confirmEnterPasscodeCoordinator: LockEnterPasscodeCoordinator = {
+        return LockEnterPasscodeCoordinator(model: LockEnterPasscodeViewModel())
+    }()
     lazy var submitButton: UIButton = {
         let button = Button(size: .large, style: .solid)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -207,13 +210,19 @@ class ConfirmPaymentViewController: UIViewController {
     }
 
     @objc func send() {
-        self.displayLoading()
+        confirmEnterPasscodeCoordinator.start { [weak self] (success, _) in
+            if success {
+                self?.displayLoading()
 
-        let transaction = configurator.signTransaction
-        self.sendTransactionCoordinator.send(transaction: transaction) { [weak self] result in
-            guard let `self` = self else { return }
-            self.didCompleted?(result)
-            self.hideLoading()
+                guard let transaction = self?.configurator.signTransaction else {
+                    return
+                }
+                self?.sendTransactionCoordinator.send(transaction: transaction) { [weak self] result in
+                    guard let `self` = self else { return }
+                    self.didCompleted?(result)
+                    self.hideLoading()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Referencing #830, I will create new coordinator for this one, and reuse the `LockEnterPasscodeViewController`.
I would like to get some info before finishing:

1. Should we include biometric confirm, as well as passcode?
2. Should we include 'Cancel' button for passcode screen? If so, should we store the current number of unsuccessful attempts?
3. If the number of unsuccessful attempts is exceeded, should we log the user out? 
