### PR TITLE
ImportWalletViewController: Fix addressRow crash

### DIFF
--- a/Trust/Wallet/ViewControllers/ImportWalletViewController.swift
+++ b/Trust/Wallet/ViewControllers/ImportWalletViewController.swift
@@ -180,6 +180,8 @@ final class ImportWalletViewController: FormViewController {
     func importWallet() {
         let validatedError = keystoreRow?.section?.form?.validate()
         guard let errors = validatedError, errors.isEmpty else { return }
+        let validatedAdressError = addressRow?.section?.form?.validate()
+        guard let addressErrors = validatedAdressError, addressErrors.isEmpty else { return }
 
         let keystoreInput = keystoreRow?.value?.trimmed ?? ""
         let privateKeyInput = privateKeyRow?.value?.trimmed ?? ""


### PR DESCRIPTION
Fix unvalidated addressRow crash that happens when a user enters an invalid address during import, but still decides to submit the form.