### PR TITLE
FIX decimal separator should be used from Locale

### DIFF
--- a/Trust/Foundation/EtherNumberFormatter.swift
+++ b/Trust/Foundation/EtherNumberFormatter.swift
@@ -25,9 +25,12 @@ final class EtherNumberFormatter {
 
     /// Thousands separator.
     var groupingSeparator = ","
+    
+    let locale: Locale
 
     /// Initializes a `EtherNumberFormatter` with a `Locale`.
     init(locale: Locale = .current) {
+        self.locale = locale
         decimalSeparator = locale.decimalSeparator ?? "."
         groupingSeparator = locale.groupingSeparator ?? ","
     }
@@ -121,7 +124,7 @@ final class EtherNumberFormatter {
         if fractionalString.isEmpty {
             return Decimal(string: integerString)
         }
-        return Decimal(string: "\(integerString)\(self.decimalSeparator)\(fractionalString)")
+        return Decimal(string: "\(integerString)\(self.decimalSeparator)\(fractionalString)", locale: locale)
     }
     private func integerString(from: BigInt) -> String {
         var string = from.description

--- a/Trust/Foundation/EtherNumberFormatter.swift
+++ b/Trust/Foundation/EtherNumberFormatter.swift
@@ -103,7 +103,7 @@ final class EtherNumberFormatter {
         if fractionalString.isEmpty {
             return integerString
         }
-        return "\(integerString).\(fractionalString)"
+        return "\(integerString)\(self.decimalSeparator)\(fractionalString)"
     }
     /// Formats a `BigInt` to a Decimal.
     ///
@@ -121,7 +121,7 @@ final class EtherNumberFormatter {
         if fractionalString.isEmpty {
             return Decimal(string: integerString)
         }
-        return Decimal(string: "\(integerString).\(fractionalString)")
+        return Decimal(string: "\(integerString)\(self.decimalSeparator)\(fractionalString)")
     }
     private func integerString(from: BigInt) -> String {
         var string = from.description


### PR DESCRIPTION
Change device language to some languages that use , as decimal separator.
Value 10,903,322.323 is displaying as 10.903.322.323 while it should be 10.903.322,323