### PR TITLE
Fix currency use user local.

### DIFF
--- a/Trust/Settings/Types/Config.swift
+++ b/Trust/Settings/Types/Config.swift
@@ -29,7 +29,7 @@ struct Config {
             }
             //If ther is not saved currency try to use user local currency if it is supported.
             let avaliableCurrency = Currency.allValues.first { currency in
-                return currency.rawValue == Locale.current.currencySymbol
+                return currency.rawValue == Locale.current.currencyCode
             }
             if let isAvaliableCurrency = avaliableCurrency {
                 return isAvaliableCurrency


### PR DESCRIPTION
currencyCode return like "USD", "EUR", and "JPY". [Link](https://developer.apple.com/documentation/foundation/nslocale/1642836-currencycode)
currencySymbol return like "$", "€", and "¥". [Link](https://developer.apple.com/documentation/foundation/nslocale/1642814-currencysymbol)

Currency use USD etc. as rawValue, so it should be currencyCode to initialize Currency.